### PR TITLE
#bug Fix nested additions not marked as changed

### DIFF
--- a/.changes/22-bug.md
+++ b/.changes/22-bug.md
@@ -1,0 +1,1 @@
+Fix nested additions not marked as changed

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,18 +47,6 @@ jobs:
               with:
                 fetch-depth: 0
 
-            - name: Check if release branch exists
-              id: check_branch
-              run: |
-                git fetch origin
-                if git show-ref --verify --quiet refs/remotes/origin/release-vsix; then
-                  echo "Release branch exists, skipping version bump"
-                  echo "should_bump=false" >> $GITHUB_OUTPUT
-                else
-                  echo "Release branch doesn't exist, will bump version"
-                  echo "should_bump=true" >> $GITHUB_OUTPUT
-                fi
-
             - name: Install dependencies
               run: |
                 npm install
@@ -74,7 +62,6 @@ jobs:
                 git config --global user.name "luau-ast-explorer-bot"
 
             - name: Bump Version
-              if: ${{ steps.check_branch.outputs.should_bump == 'true' }}
               run: |
                 npm version patch
             

--- a/frontend/src/TreeNode.tsx
+++ b/frontend/src/TreeNode.tsx
@@ -12,6 +12,7 @@ interface TreeNodeProps {
   isDiffMode?: boolean;
   diffStatus?:
     | "added"
+    | "nested-add"
     | "removed"
     | "updated"
     | "unchanged"
@@ -470,6 +471,7 @@ interface TreeNodeContainerProps {
   isDiffMode?: boolean;
   diffStatus?:
     | "added"
+    | "nested-add"
     | "removed"
     | "updated"
     | "unchanged"

--- a/frontend/src/diffUtils.ts
+++ b/frontend/src/diffUtils.ts
@@ -213,7 +213,7 @@ function annotateDiffTreeRecursive(
               changeMap,
               beforeChildNode?.[index],
               arrayPath,
-              node.diffStatus == "added" || node.diffStatus == "nested-add",
+              node.diffStatus === "added" || node.diffStatus === "nested-add",
             );
           }
         });
@@ -224,7 +224,7 @@ function annotateDiffTreeRecursive(
           changeMap,
           beforeChildNode,
           childPath,
-          node.diffStatus == "added" || node.diffStatus == "nested-add",
+          node.diffStatus === "added" || node.diffStatus === "nested-add",
         );
       }
     });

--- a/frontend/src/typesAndInterfaces.ts
+++ b/frontend/src/typesAndInterfaces.ts
@@ -53,6 +53,7 @@ export interface ASTNode {
 export interface DiffASTNode extends ASTNode {
   diffStatus?:
     | "added"
+    | "nested-add"
     | "removed"
     | "updated"
     | "unchanged"


### PR DESCRIPTION
Currently, only the exact node that is added is marked as `added`; all of the added nodes children are marked as unchanged. To ensure these children don't auto-collapse, we add a new annotation for them, `nested-add` (name subject to change)