### PR TITLE
#bug Ensure arrays with nested additions are properly annotated

### DIFF
--- a/.changes/23-bug.md
+++ b/.changes/23-bug.md
@@ -1,0 +1,1 @@
+Ensure arrays with nested additions are properly annotated

--- a/frontend/src/diffUtils.ts
+++ b/frontend/src/diffUtils.ts
@@ -204,7 +204,7 @@ function annotateDiffTreeRecursive(
         (node[key] as any).diffStatus =
           arrayDescendantChanges > 0 ? "contains-nested-changes" : "unchanged";
         // if node[key] is array, we don't call annotate on the array itself, so make sure we assign nested-add appropriately
-        if (node.diffStatus == "added" || hasAdd) {
+        if (node.diffStatus === "added" || hasAdd) {
           (node[key] as any).diffStatus = "nested-add";
         }
 

--- a/frontend/src/diffUtils.ts
+++ b/frontend/src/diffUtils.ts
@@ -203,6 +203,10 @@ function annotateDiffTreeRecursive(
         ).length;
         (node[key] as any).diffStatus =
           arrayDescendantChanges > 0 ? "contains-nested-changes" : "unchanged";
+        // if node[key] is array, we don't call annotate on the array itself, so make sure we assign nested-add appropriately
+        if (node.diffStatus == "added" || hasAdd) {
+          (node[key] as any).diffStatus = "nested-add";
+        }
 
         // Handle arrays - use dot notation to match json-diff-ts format
         node[key].forEach((item: any, index: number) => {
@@ -213,7 +217,7 @@ function annotateDiffTreeRecursive(
               changeMap,
               beforeChildNode?.[index],
               arrayPath,
-              node.diffStatus === "added" || node.diffStatus === "nested-add",
+              node.diffStatus === "added" || hasAdd
             );
           }
         });
@@ -224,7 +228,7 @@ function annotateDiffTreeRecursive(
           changeMap,
           beforeChildNode,
           childPath,
-          node.diffStatus === "added" || node.diffStatus === "nested-add",
+          node.diffStatus === "added" || hasAdd,
         );
       }
     });


### PR DESCRIPTION
Arrays are not directly annotated in the `annotateDiffTreeRecursive` pass; this leads to arrays being marked as unchanged (even if they are the children of a direct addition, a case we want to avoid). This can lead to array nodes auto-collapsing in diff mode when we don't want them to.

This PR ensures arrays are annotated as `nested-add` in the appropriate cases.