### PR TITLE
#bug Fix DiffUtils inconsistencies that require redundant logic in TreeNode

### DIFF
--- a/.changes/25-bug.md
+++ b/.changes/25-bug.md
@@ -1,1 +1,1 @@
-Fix DiffUtils inconsistencies that require redundant logic in TreeNode
+Fix `diffUtils` inconsistencies that enforce redundant logic in `TreeNode` -> remove redundant logic

--- a/.changes/25-bug.md
+++ b/.changes/25-bug.md
@@ -1,0 +1,1 @@
+Fix DiffUtils inconsistencies that require redundant logic in TreeNode

--- a/.changes/25-bug.md
+++ b/.changes/25-bug.md
@@ -1,1 +1,1 @@
-Fix `diffUtils` inconsistencies that enforce redundant logic in `TreeNode` -> remove redundant logic
+Fix `diffUtils` inconsistencies that enforce redundant logic in `TreeNode` and remove the redundant logic.

--- a/frontend/src/TreeNode.tsx
+++ b/frontend/src/TreeNode.tsx
@@ -77,7 +77,7 @@ export const TreeNode: React.FC<TreeNodeProps> = ({
     }
   };
 
-  const getChildDiffProps = (value: any, key: string | number, child: any) => {
+  const getChildDiffProps = React.useCallback((value: any, key: string | number, child: any) => {
     const nodeChildChanges = (value as any)?.childChanges || {};
     const childChange =
       nodeChildChanges[typeof key == "number" ? key.toString() : key];
@@ -108,7 +108,7 @@ export const TreeNode: React.FC<TreeNodeProps> = ({
           };
 
     return childDiffProps;
-  };
+  }, [isDiffMode]);
 
   const diffClassName = getDiffClassName();
 

--- a/frontend/src/TreeNode.tsx
+++ b/frontend/src/TreeNode.tsx
@@ -113,7 +113,7 @@ export const TreeNode: React.FC<TreeNodeProps> = ({
   const diffClassName = getDiffClassName();
 
   // Simple highlight with pronounced styling
-  const highlightText = (text: string) => {
+  const highlightText = React.useCallback((text: string) => {
     if (!searchTerm) return text;
     const regex = new RegExp(searchTerm, "gi");
     const parts = text.split(regex);
@@ -130,7 +130,7 @@ export const TreeNode: React.FC<TreeNodeProps> = ({
       }
       return acc;
     }, [] as React.ReactNode[]);
-  };
+  }, [searchTerm])
 
   // Render diff indicator for changed values - always render to maintain consistent indentation
   const renderDiffIndicator = React.useCallback(() => {

--- a/frontend/src/TreeNode.tsx
+++ b/frontend/src/TreeNode.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { TypeTooltip } from "./components/TypeTooltip";
 import { shouldAutoCollapse } from "./nodeEmphasisHelpers";
 import { JSX } from "react/jsx-runtime";
-import { render } from "@testing-library/react";
 
 interface TreeNodeProps {
   nodeKey: string;
@@ -42,7 +41,7 @@ export const TreeNode: React.FC<TreeNodeProps> = ({
   const baseIndent = "  ".repeat(level);
   const indent = baseIndent;
 
-  const renderTypeAnnotations = () => {
+  const renderTypeAnnotations = React.useCallback(() => {
     if (value._astType) {
       return (
         <span className="ast-annotations">
@@ -58,7 +57,7 @@ export const TreeNode: React.FC<TreeNodeProps> = ({
       );
     }
     return null;
-  };
+  }, [value]);
 
   // Get diff-specific styling
   const getDiffClassName = () => {
@@ -134,7 +133,7 @@ export const TreeNode: React.FC<TreeNodeProps> = ({
   };
 
   // Render diff indicator for changed values - always render to maintain consistent indentation
-  const renderDiffIndicator = () => {
+  const renderDiffIndicator = React.useCallback(() => {
     if (!isDiffMode) return <span className="diff-indicator"></span>;
 
     switch (diffStatus) {
@@ -149,48 +148,51 @@ export const TreeNode: React.FC<TreeNodeProps> = ({
       default:
         return <span className="diff-indicator"></span>;
     }
-  };
+  }, [isDiffMode, diffStatus]);
 
   // Render value with diff information
-  const renderValueWithDiff = (displayValue: string) => {
-    if (!isDiffMode) {
-      return highlightText(`${nodeKey}: ${displayValue}`);
-    }
-    // Fall back to node's own diff status
-    if (diffStatus === "unchanged") {
-      return highlightText(`${nodeKey}: ${displayValue}`);
-    }
+  const renderValueWithDiff = React.useCallback(
+    (displayValue: string) => {
+      if (!isDiffMode) {
+        return highlightText(`${nodeKey}: ${displayValue}`);
+      }
+      // Fall back to node's own diff status
+      if (diffStatus === "unchanged") {
+        return highlightText(`${nodeKey}: ${displayValue}`);
+      }
 
-    switch (diffStatus) {
-      case "added":
-        return highlightText(`${nodeKey}: ${displayValue}`);
-      case "removed":
-        const beforeDisplayValue =
-          typeof beforeValue === "string"
-            ? `"${beforeValue}"`
-            : String(beforeValue);
-        return highlightText(`${nodeKey}: ${beforeDisplayValue}`);
-      case "updated":
-        const beforeDisplay =
-          typeof beforeValue === "string"
-            ? `"${beforeValue}"`
-            : String(beforeValue);
-        const afterDisplay =
-          typeof afterValue === "string"
-            ? `"${afterValue}"`
-            : String(afterValue);
-        return (
-          <>
-            {highlightText(`${nodeKey}: `)}
-            <span className="diff-before">{beforeDisplay}</span>
-            <span className="diff-arrow"> → </span>
-            <span className="diff-after">{afterDisplay}</span>
-          </>
-        );
-      default:
-        return highlightText(`${nodeKey}: ${displayValue}`);
-    }
-  };
+      switch (diffStatus) {
+        case "added":
+          return highlightText(`${nodeKey}: ${displayValue}`);
+        case "removed":
+          const beforeDisplayValue =
+            typeof beforeValue === "string"
+              ? `"${beforeValue}"`
+              : String(beforeValue);
+          return highlightText(`${nodeKey}: ${beforeDisplayValue}`);
+        case "updated":
+          const beforeDisplay =
+            typeof beforeValue === "string"
+              ? `"${beforeValue}"`
+              : String(beforeValue);
+          const afterDisplay =
+            typeof afterValue === "string"
+              ? `"${afterValue}"`
+              : String(afterValue);
+          return (
+            <>
+              {highlightText(`${nodeKey}: `)}
+              <span className="diff-before">{beforeDisplay}</span>
+              <span className="diff-arrow"> → </span>
+              <span className="diff-after">{afterDisplay}</span>
+            </>
+          );
+        default:
+          return highlightText(`${nodeKey}: ${displayValue}`);
+      }
+    },
+    [isDiffMode, diffStatus, beforeValue, afterValue, nodeKey, highlightText]
+  );
 
   const arrow = expanded ? "▼" : "▶";
 

--- a/frontend/src/TreeNode.tsx
+++ b/frontend/src/TreeNode.tsx
@@ -77,60 +77,66 @@ export const TreeNode: React.FC<TreeNodeProps> = ({
     }
   };
 
-  const getChildDiffProps = React.useCallback((value: any, key: string | number, child: any) => {
-    const nodeChildChanges = (value as any)?.childChanges || {};
-    const childChange =
-      nodeChildChanges[typeof key == "number" ? key.toString() : key];
+  const getChildDiffProps = React.useCallback(
+    (value: any, key: string | number, child: any) => {
+      const nodeChildChanges = (value as any)?.childChanges || {};
+      const childChange =
+        nodeChildChanges[typeof key == "number" ? key.toString() : key];
 
-    const childDiffProps =
-      child && typeof child === "object" && "diffStatus" in child
-        ? {
-            isDiffMode,
-            diffStatus: child.diffStatus,
-            beforeValue: child.beforeValue,
-            afterValue: child.afterValue,
-          }
-        : childChange // handles cases where child is primitive value
-        ? {
-            isDiffMode,
-            diffStatus:
-              childChange.type === "ADD"
-                ? ("added" as const)
-                : childChange.type === "REMOVE"
-                ? ("removed" as const)
-                : ("updated" as const),
-            beforeValue: childChange.oldValue,
-            afterValue: childChange.value,
-          }
-        : {
-            isDiffMode,
-            diffStatus: "unchanged" as const,
-          };
+      const childDiffProps =
+        child && typeof child === "object" && "diffStatus" in child
+          ? {
+              isDiffMode,
+              diffStatus: child.diffStatus,
+              beforeValue: child.beforeValue,
+              afterValue: child.afterValue,
+            }
+          : childChange // handles cases where child is primitive value
+          ? {
+              isDiffMode,
+              diffStatus:
+                childChange.type === "ADD"
+                  ? ("added" as const)
+                  : childChange.type === "REMOVE"
+                  ? ("removed" as const)
+                  : ("updated" as const),
+              beforeValue: childChange.oldValue,
+              afterValue: childChange.value,
+            }
+          : {
+              isDiffMode,
+              diffStatus: "unchanged" as const,
+            };
 
-    return childDiffProps;
-  }, [isDiffMode]);
+      return childDiffProps;
+    },
+    [isDiffMode]
+  );
 
   const diffClassName = getDiffClassName();
 
   // Simple highlight with pronounced styling
-  const highlightText = React.useCallback((text: string) => {
-    if (!searchTerm) return text;
-    const regex = new RegExp(searchTerm, "gi");
-    const parts = text.split(regex);
-    const matches = text.match(regex) || [];
+  const highlightText = React.useCallback(
+    (text: string) => {
+      if (!searchTerm) return text;
+      const regex = new RegExp(searchTerm, "gi");
+      const parts = text.split(regex);
+      const matches = text.match(regex) || [];
 
-    return parts.reduce((acc, part, i) => {
-      acc.push(part);
-      if (matches[i]) {
-        acc.push(
-          <mark key={i} className="search-match tree-highlight">
-            {matches[i]}
-          </mark>
-        );
-      }
-      return acc;
-    }, [] as React.ReactNode[]);
-  }, [searchTerm])
+      return parts.reduce((acc, part, i) => {
+        acc.push(part);
+        if (matches[i]) {
+          acc.push(
+            <mark key={i} className="search-match tree-highlight">
+              {matches[i]}
+            </mark>
+          );
+        }
+        return acc;
+      }, [] as React.ReactNode[]);
+    },
+    [searchTerm]
+  );
 
   // Render diff indicator for changed values - always render to maintain consistent indentation
   const renderDiffIndicator = React.useCallback(() => {

--- a/frontend/src/TreeNode.tsx
+++ b/frontend/src/TreeNode.tsx
@@ -1,8 +1,8 @@
-import React, { ReactElement } from "react";
+import React from "react";
 import { TypeTooltip } from "./components/TypeTooltip";
 import { shouldAutoCollapse } from "./nodeEmphasisHelpers";
-import { render } from "@testing-library/react";
 import { JSX } from "react/jsx-runtime";
+import { render } from "@testing-library/react";
 
 interface TreeNodeProps {
   nodeKey: string;
@@ -77,39 +77,6 @@ export const TreeNode: React.FC<TreeNodeProps> = ({
         return "";
     }
   };
-
-  const arrow = expanded ? "▼" : "▶";
-
-  const getRenderedContent = React.useCallback(
-    (
-      renderArrow: boolean,
-      renderValue: string | JSX.Element | React.ReactNode[],
-      renderTypeAnnotation: boolean,
-      isArray?: boolean
-    ) => {
-      return (
-        <React.Fragment>
-          {indent}
-          {renderArrow ? (
-            <span
-              className="tree-arrow"
-              style={{
-                color: isArray
-                  ? "var(--vscode-symbolIcon-arrayForeground)"
-                  : "var(--vscode-symbolIcon-objectForeground)",
-              }}
-            >
-              {arrow}
-            </span>
-          ) : null}
-          {renderDiffIndicator()}
-          {renderValue}
-          {renderTypeAnnotation ? renderTypeAnnotations() : null}
-        </React.Fragment>
-      );
-    },
-    []
-  );
 
   const getChildDiffProps = (value: any, key: string | number, child: any) => {
     const nodeChildChanges = (value as any)?.childChanges || {};
@@ -224,6 +191,39 @@ export const TreeNode: React.FC<TreeNodeProps> = ({
         return highlightText(`${nodeKey}: ${displayValue}`);
     }
   };
+
+  const arrow = expanded ? "▼" : "▶";
+
+  const getRenderedContent = React.useCallback(
+    (
+      renderArrow: boolean,
+      renderValue: string | JSX.Element | React.ReactNode[],
+      renderTypeAnnotation: boolean,
+      isArray?: boolean
+    ) => {
+      return (
+        <React.Fragment>
+          {indent}
+          {renderArrow ? (
+            <span
+              className="tree-arrow"
+              style={{
+                color: isArray
+                  ? "var(--vscode-symbolIcon-arrayForeground)"
+                  : "var(--vscode-symbolIcon-objectForeground)",
+              }}
+            >
+              {arrow}
+            </span>
+          ) : null}
+          {renderDiffIndicator()}
+          {renderValue}
+          {renderTypeAnnotation ? renderTypeAnnotations() : null}
+        </React.Fragment>
+      );
+    },
+    [arrow, indent, renderDiffIndicator, renderTypeAnnotations]
+  );
 
   // Render primitive values
   if (value === null || value === undefined) {


### PR DESCRIPTION
## Problem
- As is, `diffUtils` does not comprehensively annotate the full tree
- When we come across arrays during the recursive traversal, they are not processed with a direct call to `annotateDiffTreeRecursive` on the array itself. Instead, we process their children. Given this, we were never checking if arrays contained a direct change so ADDed arrays were incorrectly annotated as unchanged
- Because diffUtils had these inconsistencies, we had originally passed `parentChanges` through `TreeNode`, serving as a fallback to catch changes when existing `diffStatus` was incorrect. If `diffUtils` works, this logic is very redundant and just adds bloat

## Solution
Add a check for direct changes on arrays in `annotateDiffTreeRecursive`
Since this fixes annotation issues, we can remove all the redundant `parentChanges` logic in `TreeNode`
Generally consolidate repeated logic in `TreeNode`