### PR TITLE
#feat Better diff styling display

### DIFF
--- a/.changes/29-feat.md
+++ b/.changes/29-feat.md
@@ -1,0 +1,1 @@
+Better diff styling display

--- a/.changes/29-feat.md
+++ b/.changes/29-feat.md
@@ -1,1 +1,1 @@
-Better diff styling display
+Smarter diff highlight styling

--- a/frontend/src/TreeNode.tsx
+++ b/frontend/src/TreeNode.tsx
@@ -2,7 +2,12 @@ import React from "react";
 import { TypeAnnotation } from "./components/TypeAnnotation";
 import { shouldAutoCollapse } from "./nodeEmphasisHelpers";
 import { JSX } from "react/jsx-runtime";
-import { getTypeString, getType, unpackArrayType } from "./utils/astTypeHelpers";
+import {
+  getTypeString,
+  getType,
+  unpackArrayType,
+} from "./utils/astTypeHelpers";
+import exp from "constants";
 
 interface TreeNodeProps {
   nodeKey: string;
@@ -82,11 +87,13 @@ export const TreeNode: React.FC<TreeNodeProps> = ({
       case "updated":
         return "diff-updated";
       case "contains-changes":
-        return "diff-contains-changes";
+      case "contains-nested-changes":
+      case "nested-add":
+        return expanded ? "" : "diff-contains-changes";
       default:
         return "";
     }
-  }, [isDiffMode, diffStatus]);
+  }, [isDiffMode, diffStatus, expanded]);
 
   const getChildDiffProps = React.useCallback(
     (value: any, key: string | number, child: any) => {
@@ -161,11 +168,17 @@ export const TreeNode: React.FC<TreeNodeProps> = ({
       case "updated":
         return <span className="diff-indicator diff-updated-indicator">~</span>;
       case "contains-changes":
-        return <span className="diff-indicator diff-updated-indicator">○</span>;
+      case "contains-nested-changes":
+      case "nested-add":
+        return expanded ? (
+          ""
+        ) : (
+          <span className="diff-indicator diff-updated-indicator">○</span>
+        );
       default:
         return <span className="diff-indicator"></span>;
     }
-  }, [isDiffMode, diffStatus]);
+  }, [isDiffMode, diffStatus, expanded]);
 
   // Render value with diff information
   const renderValueWithDiff = React.useCallback(

--- a/frontend/src/TreeNode.tsx
+++ b/frontend/src/TreeNode.tsx
@@ -7,7 +7,6 @@ import {
   getType,
   unpackArrayType,
 } from "./utils/astTypeHelpers";
-import exp from "constants";
 
 interface TreeNodeProps {
   nodeKey: string;


### PR DESCRIPTION
## Problem

The current diff tree will highlight ancestors of the node that was directly changed. Since we auto-expand any node annotated with a diff classification, all the directly changed nodes are visible by default. This means the ancestral highlighting is often harming to the visual clarity.

## Solution

Nodes annotated as "contains-changes", "contains-nested-changes", or "nested-add" have changes in their descendant nodes. If these nodes are expanded, we can assume their descendant (who was modified and thus highlighted) is visible. Conversely, if they are collapsed, the modified descendant is not visible, so highlighting the current node to indicate a descendant change is relevant and useful.

When the descendant is visible, we get no additional information from also highlighting the ancestor node.
As such, it reduces visual clutter and adds clarity to only highlight nodes with descendant changes when they are collapsed.

![ezgif-88d360a006ff9f](https://github.com/user-attachments/assets/fe62f643-1856-410e-86fd-caacc59ad2a7)
