### PR TITLE
#feat Better TreeNode hover; display node path OR translated code

### DIFF
--- a/.changes/30-feat.md
+++ b/.changes/30-feat.md
@@ -1,1 +1,1 @@
-Add path prop to TreeNode; display on hover
+Add informative tooltip to TreeNodes on hover. If node cannot be translated (not directly parseable from AST -> code), display path. Otherwise, display corresponding code.

--- a/.changes/30-feat.md
+++ b/.changes/30-feat.md
@@ -1,0 +1,1 @@
+Add path prop to TreeNode; display on hover

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,8 @@ jobs:
                 lute lua_tests/runner.luau
 
             - name: Run frontend tests
-              run: npm run test
+              run: |
+                cd frontend && npm test
 
     build:
         runs-on: ubuntu-latest

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,6 +17,7 @@
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
         "highlight.js": "^11.11.1",
+        "highlightjs-luau": "^1.0.2",
         "json-diff-ts": "^4.8.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -8884,6 +8885,12 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/highlightjs-luau": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/highlightjs-luau/-/highlightjs-luau-1.0.2.tgz",
+      "integrity": "sha512-Ok3w6jclLPzqUlLI01DwsdO8IiSDneLrXPD+0XcBPlEw9JrzI2zZGeB9EcLASzifSSBz1f95mhJ7YuzxVz1x/w==",
+      "license": "MIT"
     },
     "node_modules/hoopy": {
       "version": "0.1.4",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,6 +16,7 @@
         "@types/node": "^16.18.126",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
+        "highlight.js": "^11.11.1",
         "json-diff-ts": "^4.8.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -8873,6 +8874,15 @@
       "license": "MIT",
       "bin": {
         "he": "bin/he"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
+      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/hoopy": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,7 +17,6 @@
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
         "highlight.js": "^11.11.1",
-        "highlightjs-luau": "^1.0.2",
         "json-diff-ts": "^4.8.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -8885,12 +8884,6 @@
       "engines": {
         "node": ">=12.0.0"
       }
-    },
-    "node_modules/highlightjs-luau": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/highlightjs-luau/-/highlightjs-luau-1.0.2.tgz",
-      "integrity": "sha512-Ok3w6jclLPzqUlLI01DwsdO8IiSDneLrXPD+0XcBPlEw9JrzI2zZGeB9EcLASzifSSBz1f95mhJ7YuzxVz1x/w==",
-      "license": "MIT"
     },
     "node_modules/hoopy": {
       "version": "0.1.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,7 +22,8 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test",
+    "test": "react-scripts test --watchAll=false",
+    "test:watch": "react-scripts test",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,6 @@
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "highlight.js": "^11.11.1",
-    "highlightjs-luau": "^1.0.2",
     "json-diff-ts": "^4.8.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
     "@types/node": "^16.18.126",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
+    "highlight.js": "^11.11.1",
     "json-diff-ts": "^4.8.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "highlight.js": "^11.11.1",
+    "highlightjs-luau": "^1.0.2",
     "json-diff-ts": "^4.8.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,7 +16,7 @@ import {
 } from "./typesAndInterfaces";
 import LiveEditor from "./LiveEditor";
 import DiffAnalyzer from "./DiffAnalyzer";
-import { useCodeTooltip } from "./hooks/useCodeTooltip";
+import { useCodeTranslation } from "./hooks/useCodeTranslation";
 
 const App: React.FC = () => {
   // Get all available node keys and start with none hidden (all visible)
@@ -72,7 +72,7 @@ const App: React.FC = () => {
     codeTooltips,
     requestCodeTooltip,
     generateNodeId,
-  } = useCodeTooltip(vscodeApi);
+  } = useCodeTranslation(vscodeApi);
 
   // Set up VSCode API and message listener
   useEffect(() => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,6 +17,7 @@ import {
 import LiveEditor from "./LiveEditor";
 import DiffAnalyzer from "./DiffAnalyzer";
 import { useCodeTranslation } from "./hooks/useCodeTranslation";
+import { CodeTranslationContext } from "./context/codeTranslationContext";
 
 const App: React.FC = () => {
   // Get all available node keys and start with none hidden (all visible)
@@ -151,9 +152,6 @@ const App: React.FC = () => {
             parseError={parseError || ""}
             astTree={astTree!}
             searchTerm={searchTerm}
-            codeTooltips={codeTooltips}
-            requestCodeTooltip={requestCodeTooltip}
-            generateNodeId={generateNodeId}
           />
         );
 
@@ -172,9 +170,6 @@ const App: React.FC = () => {
             diffTree={diffTree!}
             hiddenNodes={hiddenNodes}
             setHiddenNodes={setHiddenNodes}
-            codeTooltips={codeTooltips}
-            requestCodeTooltip={requestCodeTooltip}
-            generateNodeId={generateNodeId}
           />
         );
 
@@ -238,7 +233,15 @@ const App: React.FC = () => {
         )}
       </div>
 
-      {renderWindowContent()}
+      <CodeTranslationContext.Provider
+        value={{
+          codeTooltips: codeTooltips,
+          requestCodeTooltip: requestCodeTooltip,
+          generateNodeId: generateNodeId,
+        }}
+      >
+        {renderWindowContent()}
+      </CodeTranslationContext.Provider>
     </div>
   );
 };

--- a/frontend/src/DiffAnalyzer.tsx
+++ b/frontend/src/DiffAnalyzer.tsx
@@ -87,7 +87,7 @@ const DiffAnalyzer = ({
           <div className="ast-content tree-view">
             <TreeNodeContainer
               nodeKey="root"
-              path=""
+              path="root"
               value={diffTree}
               level={0}
               isDiffMode={true}

--- a/frontend/src/DiffAnalyzer.tsx
+++ b/frontend/src/DiffAnalyzer.tsx
@@ -16,9 +16,6 @@ interface DiffAnalyzerProps {
   diffTree: ASTNode;
   hiddenNodes: string[];
   setHiddenNodes: (hiddenNodes: string[]) => void;
-  codeTooltips: Record<string, string>;
-  requestCodeTooltip: (nodeValue: any, nodeKey: string) => void;
-  generateNodeId: (nodeValue: any, nodeKey: string) => string;
 }
 
 const DiffAnalyzer = ({
@@ -33,9 +30,6 @@ const DiffAnalyzer = ({
   diffTree,
   hiddenNodes,
   setHiddenNodes,
-  codeTooltips,
-  requestCodeTooltip,
-  generateNodeId,
 }: DiffAnalyzerProps) => {
   return (
     <div className="diff-analyzer-layout">
@@ -99,9 +93,6 @@ const DiffAnalyzer = ({
               isDiffMode={true}
               hiddenNodes={hiddenNodes}
               vscodeApi={vscodeApi}
-              codeTooltips={codeTooltips}
-              requestCodeTooltip={requestCodeTooltip}
-              generateNodeId={generateNodeId}
             />
           </div>
         ) : (

--- a/frontend/src/DiffAnalyzer.tsx
+++ b/frontend/src/DiffAnalyzer.tsx
@@ -87,6 +87,7 @@ const DiffAnalyzer = ({
           <div className="ast-content tree-view">
             <TreeNodeContainer
               nodeKey="root"
+              path=""
               value={diffTree}
               level={0}
               isDiffMode={true}

--- a/frontend/src/DiffAnalyzer.tsx
+++ b/frontend/src/DiffAnalyzer.tsx
@@ -92,6 +92,7 @@ const DiffAnalyzer = ({
               level={0}
               isDiffMode={true}
               hiddenNodes={hiddenNodes}
+              vscodeApi={vscodeApi}
             />
           </div>
         ) : (

--- a/frontend/src/DiffAnalyzer.tsx
+++ b/frontend/src/DiffAnalyzer.tsx
@@ -16,6 +16,9 @@ interface DiffAnalyzerProps {
   diffTree: ASTNode;
   hiddenNodes: string[];
   setHiddenNodes: (hiddenNodes: string[]) => void;
+  codeTooltips: Record<string, string>;
+  requestCodeTooltip: (nodeValue: any, nodeKey: string) => void;
+  generateNodeId: (nodeValue: any, nodeKey: string) => string;
 }
 
 const DiffAnalyzer = ({
@@ -30,6 +33,9 @@ const DiffAnalyzer = ({
   diffTree,
   hiddenNodes,
   setHiddenNodes,
+  codeTooltips,
+  requestCodeTooltip,
+  generateNodeId,
 }: DiffAnalyzerProps) => {
   return (
     <div className="diff-analyzer-layout">
@@ -93,6 +99,9 @@ const DiffAnalyzer = ({
               isDiffMode={true}
               hiddenNodes={hiddenNodes}
               vscodeApi={vscodeApi}
+              codeTooltips={codeTooltips}
+              requestCodeTooltip={requestCodeTooltip}
+              generateNodeId={generateNodeId}
             />
           </div>
         ) : (

--- a/frontend/src/DiffAnalyzer.tsx
+++ b/frontend/src/DiffAnalyzer.tsx
@@ -92,7 +92,6 @@ const DiffAnalyzer = ({
               level={0}
               isDiffMode={true}
               hiddenNodes={hiddenNodes}
-              vscodeApi={vscodeApi}
             />
           </div>
         ) : (

--- a/frontend/src/LiveEditor.tsx
+++ b/frontend/src/LiveEditor.tsx
@@ -64,6 +64,7 @@ const LiveEditor = ({
             <div className="ast-content tree-view">
               <TreeNodeContainer
                 nodeKey="root"
+                path=""
                 value={astTree}
                 level={0}
                 searchTerm={searchTerm}

--- a/frontend/src/LiveEditor.tsx
+++ b/frontend/src/LiveEditor.tsx
@@ -15,6 +15,9 @@ interface LiverEditorProps {
   parseError: string;
   astTree: ASTNode;
   searchTerm: string;
+  codeTooltips: Record<string, string>;
+  requestCodeTooltip: (nodeValue: any, nodeKey: string) => void;
+  generateNodeId: (nodeValue: any, nodeKey: string) => string;
 }
 
 const LiveEditor = ({
@@ -28,6 +31,9 @@ const LiveEditor = ({
   parseError,
   astTree,
   searchTerm,
+  codeTooltips,
+  requestCodeTooltip,
+  generateNodeId,
 }: LiverEditorProps) => {
   return (
     <div className="live-editor-layout">
@@ -70,6 +76,9 @@ const LiveEditor = ({
                 searchTerm={searchTerm}
                 hiddenNodes={hiddenNodes}
                 vscodeApi={vscodeApi}
+                codeTooltips={codeTooltips}
+                requestCodeTooltip={requestCodeTooltip}
+                generateNodeId={generateNodeId}
               />
             </div>
           ) : (

--- a/frontend/src/LiveEditor.tsx
+++ b/frontend/src/LiveEditor.tsx
@@ -69,7 +69,6 @@ const LiveEditor = ({
                 level={0}
                 searchTerm={searchTerm}
                 hiddenNodes={hiddenNodes}
-                vscodeApi={vscodeApi}
               />
             </div>
           ) : (

--- a/frontend/src/LiveEditor.tsx
+++ b/frontend/src/LiveEditor.tsx
@@ -15,9 +15,6 @@ interface LiverEditorProps {
   parseError: string;
   astTree: ASTNode;
   searchTerm: string;
-  codeTooltips: Record<string, string>;
-  requestCodeTooltip: (nodeValue: any, nodeKey: string) => void;
-  generateNodeId: (nodeValue: any, nodeKey: string) => string;
 }
 
 const LiveEditor = ({
@@ -31,9 +28,6 @@ const LiveEditor = ({
   parseError,
   astTree,
   searchTerm,
-  codeTooltips,
-  requestCodeTooltip,
-  generateNodeId,
 }: LiverEditorProps) => {
   return (
     <div className="live-editor-layout">
@@ -76,9 +70,6 @@ const LiveEditor = ({
                 searchTerm={searchTerm}
                 hiddenNodes={hiddenNodes}
                 vscodeApi={vscodeApi}
-                codeTooltips={codeTooltips}
-                requestCodeTooltip={requestCodeTooltip}
-                generateNodeId={generateNodeId}
               />
             </div>
           ) : (

--- a/frontend/src/LiveEditor.tsx
+++ b/frontend/src/LiveEditor.tsx
@@ -64,7 +64,7 @@ const LiveEditor = ({
             <div className="ast-content tree-view">
               <TreeNodeContainer
                 nodeKey="root"
-                path=""
+                path="root"
                 value={astTree}
                 level={0}
                 searchTerm={searchTerm}

--- a/frontend/src/LiveEditor.tsx
+++ b/frontend/src/LiveEditor.tsx
@@ -69,6 +69,7 @@ const LiveEditor = ({
                 level={0}
                 searchTerm={searchTerm}
                 hiddenNodes={hiddenNodes}
+                vscodeApi={vscodeApi}
               />
             </div>
           ) : (

--- a/frontend/src/TreeNode.tsx
+++ b/frontend/src/TreeNode.tsx
@@ -7,6 +7,8 @@ import {
   getType,
   unpackArrayType,
 } from "./utils/astTypeHelpers";
+import { useCodeTooltip } from './hooks/useCodeTooltip';
+import { VSCodeAPI } from './typesAndInterfaces';
 
 interface TreeNodeProps {
   nodeKey: string;
@@ -29,6 +31,7 @@ interface TreeNodeProps {
   beforeValue?: any;
   afterValue?: any;
   hiddenNodes?: string[];
+  vscodeApi?: VSCodeAPI | null;
 }
 
 export const TreeNode: React.FC<TreeNodeProps> = ({
@@ -45,6 +48,7 @@ export const TreeNode: React.FC<TreeNodeProps> = ({
   beforeValue,
   afterValue,
   hiddenNodes = [],
+  vscodeApi = null,
 }) => {
   // Always reserve space for diff indicator to maintain consistent indentation
   const baseIndent = "  ".repeat(level);
@@ -258,10 +262,13 @@ export const TreeNode: React.FC<TreeNodeProps> = ({
     [arrow, indent, renderDiffIndicator, renderTypeAnnotations]
   );
 
+  // Add the code tooltip hook
+  const { getTooltipContent } = useCodeTooltip(vscodeApi);
+
   // Render primitive values
   if (value === null || value === undefined) {
     return (
-      <div className={diffClassName} title={path}>
+      <div className={diffClassName} title={getTooltipContent(value, nodeKey, path)}>
         {getRenderedContent(false, renderValueWithDiff("null"), false)}
       </div>
     );
@@ -272,7 +279,7 @@ export const TreeNode: React.FC<TreeNodeProps> = ({
     const displayValue =
       typeof value === "string" ? `"${value}"` : String(value);
     return (
-      <div className={diffClassName} title={path}>
+      <div className={diffClassName} title={getTooltipContent(value, nodeKey, path)}>
         {/* include empty span to ensure indentation aligns with expandable nodes */}
         <span className="tree-arrow"></span>
         {getRenderedContent(false, renderValueWithDiff(displayValue), false)}
@@ -299,7 +306,7 @@ export const TreeNode: React.FC<TreeNodeProps> = ({
 
     return (
       <div className={diffClassName}>
-        <div style={{ cursor: "pointer" }} onClick={onToggle} title={path}>
+        <div style={{ cursor: "pointer" }} onClick={onToggle} title={getTooltipContent(value, nodeKey, path)}>
           {getRenderedContent(true, highlightText(nodeKey), true, true)}
         </div>
         {expanded &&
@@ -321,6 +328,7 @@ export const TreeNode: React.FC<TreeNodeProps> = ({
                 searchTerm={searchTerm}
                 path={`${path}.${index}`}
                 hiddenNodes={hiddenNodes}
+                vscodeApi={vscodeApi}
                 {...childDiffProps}
               />
             );
@@ -355,7 +363,7 @@ export const TreeNode: React.FC<TreeNodeProps> = ({
 
   return (
     <div className={diffClassName}>
-      <div style={{ cursor: "pointer" }} onClick={onToggle} title={path}>
+      <div style={{ cursor: "pointer" }} onClick={onToggle} title={getTooltipContent(value, nodeKey, path)}>
         {getRenderedContent(true, highlightText(nodeKey), true)}
       </div>
       {expanded &&
@@ -380,6 +388,7 @@ export const TreeNode: React.FC<TreeNodeProps> = ({
               searchTerm={searchTerm}
               hiddenNodes={hiddenNodes}
               path={`${path}.${key}`}
+              vscodeApi={vscodeApi}
               {...childDiffProps}
             />
           );
@@ -408,6 +417,7 @@ interface TreeNodeContainerProps {
   beforeValue?: any;
   afterValue?: any;
   hiddenNodes?: string[];
+  vscodeApi?: VSCodeAPI | null;
 }
 
 const TreeNodeContainer: React.FC<TreeNodeContainerProps> = (props) => {

--- a/frontend/src/TreeNode.tsx
+++ b/frontend/src/TreeNode.tsx
@@ -14,6 +14,7 @@ interface TreeNodeProps {
   level: number;
   expanded: boolean;
   onToggle: () => void;
+  path: string;
   searchTerm?: string;
   parentInferredType?: string | string[];
   isDiffMode?: boolean;
@@ -35,6 +36,7 @@ export const TreeNode: React.FC<TreeNodeProps> = ({
   value,
   level,
   expanded,
+  path,
   onToggle,
   searchTerm = "",
   isDiffMode = false,
@@ -317,8 +319,9 @@ export const TreeNode: React.FC<TreeNodeProps> = ({
                     : undefined
                 }
                 searchTerm={searchTerm}
-                {...childDiffProps}
+                path={`${path}.${index}`}
                 hiddenNodes={hiddenNodes}
+                {...childDiffProps}
               />
             );
           })}
@@ -376,6 +379,7 @@ export const TreeNode: React.FC<TreeNodeProps> = ({
               parentInferredType={parentInferredType}
               searchTerm={searchTerm}
               hiddenNodes={hiddenNodes}
+              path={`${path}.${key}`}
               {...childDiffProps}
             />
           );
@@ -389,6 +393,7 @@ interface TreeNodeContainerProps {
   nodeKey: string;
   value: any;
   level: number;
+  path: string;
   searchTerm?: string;
   parentInferredType?: string | string[];
   isDiffMode?: boolean;

--- a/frontend/src/TreeNode.tsx
+++ b/frontend/src/TreeNode.tsx
@@ -271,14 +271,7 @@ export const TreeNode: React.FC<TreeNodeProps> = ({
         requestCodeTooltip(value, nodeKey);
       }
     }
-  }, [
-    value,
-    nodeKey,
-    requestCodeTooltip,
-    codeTooltips,
-    generateNodeId,
-    nodeId,
-  ]);
+  }, [value, nodeKey, requestCodeTooltip, codeTooltips, nodeId]);
 
   // Render primitive values
   if (value === null || value === undefined) {

--- a/frontend/src/TreeNode.tsx
+++ b/frontend/src/TreeNode.tsx
@@ -60,6 +60,10 @@ export const TreeNode: React.FC<TreeNodeProps> = ({
   const baseIndent = "  ".repeat(level);
   const indent = baseIndent;
 
+  const nodeId = React.useMemo(() => {
+    return generateNodeId ? generateNodeId(value, nodeKey) : "";
+  }, [value, nodeKey]);
+
   // get all this metadata at tree node level; pass to TypeTooltip
   const [type, kind] = React.useMemo(() => {
     return getTypeString(value, nodeKey, parentInferredType);
@@ -276,7 +280,6 @@ export const TreeNode: React.FC<TreeNodeProps> = ({
       !Array.isArray(value) &&
       generateNodeId
     ) {
-      const nodeId = generateNodeId(value, nodeKey);
       return codeTooltips[nodeId] || path;
     }
     return path;
@@ -291,7 +294,6 @@ export const TreeNode: React.FC<TreeNodeProps> = ({
       generateNodeId &&
       requestCodeTooltip
     ) {
-      const nodeId = generateNodeId(value, nodeKey);
       // Only request if we don't have cached content
       if (!codeTooltips[nodeId]) {
         requestCodeTooltip(value, nodeKey);

--- a/frontend/src/TreeNode.tsx
+++ b/frontend/src/TreeNode.tsx
@@ -274,7 +274,6 @@ export const TreeNode: React.FC<TreeNodeProps> = ({
       value &&
       typeof value === "object" &&
       !Array.isArray(value) &&
-      value.tag &&
       generateNodeId
     ) {
       const nodeId = generateNodeId(value, nodeKey);
@@ -289,7 +288,6 @@ export const TreeNode: React.FC<TreeNodeProps> = ({
       value &&
       typeof value === "object" &&
       !Array.isArray(value) &&
-      value.tag &&
       generateNodeId &&
       requestCodeTooltip
     ) {

--- a/frontend/src/TreeNode.tsx
+++ b/frontend/src/TreeNode.tsx
@@ -261,7 +261,7 @@ export const TreeNode: React.FC<TreeNodeProps> = ({
   // Render primitive values
   if (value === null || value === undefined) {
     return (
-      <div className={diffClassName}>
+      <div className={diffClassName} title={path}>
         {getRenderedContent(false, renderValueWithDiff("null"), false)}
       </div>
     );
@@ -272,7 +272,7 @@ export const TreeNode: React.FC<TreeNodeProps> = ({
     const displayValue =
       typeof value === "string" ? `"${value}"` : String(value);
     return (
-      <div className={diffClassName}>
+      <div className={diffClassName} title={path}>
         {/* include empty span to ensure indentation aligns with expandable nodes */}
         <span className="tree-arrow"></span>
         {getRenderedContent(false, renderValueWithDiff(displayValue), false)}
@@ -299,7 +299,7 @@ export const TreeNode: React.FC<TreeNodeProps> = ({
 
     return (
       <div className={diffClassName}>
-        <div style={{ cursor: "pointer" }} onClick={onToggle}>
+        <div style={{ cursor: "pointer" }} onClick={onToggle} title={path}>
           {getRenderedContent(true, highlightText(nodeKey), true, true)}
         </div>
         {expanded &&
@@ -355,7 +355,7 @@ export const TreeNode: React.FC<TreeNodeProps> = ({
 
   return (
     <div className={diffClassName}>
-      <div style={{ cursor: "pointer" }} onClick={onToggle}>
+      <div style={{ cursor: "pointer" }} onClick={onToggle} title={path}>
         {getRenderedContent(true, highlightText(nodeKey), true)}
       </div>
       {expanded &&

--- a/frontend/src/TreeNode.tsx
+++ b/frontend/src/TreeNode.tsx
@@ -9,7 +9,6 @@ import {
 } from "./utils/astTypeHelpers";
 import { CodeTooltip } from "./components/CodeTooltip";
 
-import { VSCodeAPI } from "./typesAndInterfaces";
 import { ASTTypeDefinition } from "./utils/astTypeDefinitions";
 import { useCodeTranslationContext } from "./context/codeTranslationContext";
 
@@ -37,7 +36,6 @@ interface TreeNodeProps {
   beforeValue?: any;
   afterValue?: any;
   hiddenNodes?: string[];
-  vscodeApi?: VSCodeAPI | null;
 }
 
 export const TreeNode: React.FC<TreeNodeProps> = ({
@@ -57,7 +55,6 @@ export const TreeNode: React.FC<TreeNodeProps> = ({
   beforeValue,
   afterValue,
   hiddenNodes = [],
-  vscodeApi = null,
 }) => {
   // Always reserve space for diff indicator to maintain consistent indentation
   const baseIndent = "  ".repeat(level);
@@ -350,7 +347,6 @@ export const TreeNode: React.FC<TreeNodeProps> = ({
                 searchTerm={searchTerm}
                 path={`${path}.${index}`}
                 hiddenNodes={hiddenNodes}
-                vscodeApi={vscodeApi}
                 {...childDiffProps}
               />
             );
@@ -423,7 +419,6 @@ export const TreeNode: React.FC<TreeNodeProps> = ({
               searchTerm={searchTerm}
               hiddenNodes={hiddenNodes}
               path={`${path}.${key}`}
-              vscodeApi={vscodeApi}
               {...childDiffProps}
             />
           );
@@ -452,7 +447,6 @@ interface TreeNodeContainerProps {
   beforeValue?: any;
   afterValue?: any;
   hiddenNodes?: string[];
-  vscodeApi?: VSCodeAPI | null;
 }
 
 const TreeNodeContainer: React.FC<TreeNodeContainerProps> = (props) => {

--- a/frontend/src/components/CodeTooltip.css
+++ b/frontend/src/components/CodeTooltip.css
@@ -89,6 +89,7 @@
   white-space: pre; /* Prevent line wrapping */
   background: transparent; /* Use CodeTooltip background */
   min-width: 0; /* Allow shrinking */
+  tab-size: 4; /* Set tab width to 2 spaces */
 }
 
 .path-text {

--- a/frontend/src/components/CodeTooltip.css
+++ b/frontend/src/components/CodeTooltip.css
@@ -1,0 +1,71 @@
+.code-tooltip {
+  position: fixed;
+  background: var(--vscode-quickInput-background);
+  border: 1px solid var(--vscode-quickInput-border, var(--vscode-contrastBorder));
+  border-radius: 4px;
+  box-shadow: 0 4px 12px var(--vscode-widget-shadow);
+  z-index: 1000;
+  max-width: 850px; /* ~100 chars at 13px font + padding (100 * 8.5px ≈ 850px) */
+  max-height: 300px;
+  overflow: auto;
+  transform: translateY(-100%); /* Remove X centering, align to left edge */
+  font-family: var(--vscode-editor-font-family);
+  animation: tooltip-appear 0.15s ease-out;
+}
+
+@keyframes tooltip-appear {
+  from {
+    opacity: 0;
+    transform: translateY(-100%) scale(0.95);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(-100%) scale(1);
+  }
+}
+
+.code-tooltip-content {
+  padding: 8px 12px;
+}
+
+
+
+/* .path-text {
+  font-size: 13px;
+  color: var(--vscode-foreground);
+  line-height: 1.4;
+  word-break: break-all;
+} */
+
+/* Scrollbar styling */
+.code-tooltip::-webkit-scrollbar {
+  width: 8px;
+}
+
+.code-tooltip::-webkit-scrollbar-track {
+  background: var(--vscode-scrollbarSlider-background);
+}
+
+.code-tooltip::-webkit-scrollbar-thumb {
+  background: var(--vscode-scrollbarSlider-hoverBackground);
+  border-radius: 4px;
+}
+
+.code-tooltip::-webkit-scrollbar-thumb:hover {
+  background: var(--vscode-scrollbarSlider-activeBackground);
+}
+
+/* Basic code block styling - let highlight.js handle syntax colors */
+.code-block {
+  display: block;
+  overflow-x: auto;
+  padding: 0.5em;
+  margin: 0;
+  font-family: var(--vscode-editor-font-family);
+  font-size: var(--vscode-editor-font-size, 13px);
+  line-height: 1.4;
+  white-space: pre-wrap;
+  word-break: break-word;
+  background: transparent; /* Use CodeTooltip background */
+}
+

--- a/frontend/src/components/CodeTooltip.css
+++ b/frontend/src/components/CodeTooltip.css
@@ -5,7 +5,7 @@
   border-radius: 4px;
   box-shadow: 0 4px 12px var(--vscode-widget-shadow);
   z-index: 1000;
-  max-width: 850px; /* ~100 chars at 13px font + padding (100 * 8.5px ≈ 850px) */
+  /* Width is set dynamically via JavaScript based on viewport */
   max-height: 300px;
   transform: translateY(-100%); /* Remove X centering, align to left edge */
   font-family: var(--vscode-editor-font-family);
@@ -36,18 +36,11 @@
   border-radius: 4px 4px 0 0;
 }
 
-.code-tooltip-divider {
-  display: none; /* Remove separate divider since header has border-bottom */
-}
-
 .code-tooltip-content {
   padding: 8px 12px;
   overflow: auto; /* Make content scrollable */
   flex: 1; /* Take remaining space */
 }
-
-
-
 
 /* Scrollbar styling for tooltip content */
 .code-tooltip-content::-webkit-scrollbar,
@@ -79,8 +72,7 @@
 /* Basic code block styling - let highlight.js handle syntax colors */
 .code-block {
   display: block;
-  overflow-x: auto;
-  overflow-y: auto;
+  overflow: auto;
   padding: 0.5em;
   margin: 0;
   font-family: var(--vscode-editor-font-family);
@@ -89,7 +81,7 @@
   white-space: pre; /* Prevent line wrapping */
   background: transparent; /* Use CodeTooltip background */
   min-width: 0; /* Allow shrinking */
-  tab-size: 4; /* Set tab width to 2 spaces */
+  tab-size: 4; /* Set tab width to 4 spaces */
 }
 
 .path-text {

--- a/frontend/src/components/CodeTooltip.css
+++ b/frontend/src/components/CodeTooltip.css
@@ -26,21 +26,18 @@
 }
 
 .code-tooltip-header {
-  padding: 8px 12px 6px 12px;
+  padding: 8px 12px;
   font-size: 12px;
   font-weight: 600;
   color: var(--vscode-descriptionForeground);
-  background: var(--vscode-quickInput-background);
+  background: var(--vscode-editorGroupHeader-tabsBackground, var(--vscode-quickInput-background));
+  border-bottom: 1px solid var(--vscode-editorWidget-border, var(--vscode-panel-border));
   flex-shrink: 0; /* Keep header fixed */
   border-radius: 4px 4px 0 0;
 }
 
 .code-tooltip-divider {
-  height: 1px;
-  background: var(--vscode-panel-border, #464647);
-  margin: 0;
-  flex-shrink: 0; /* Keep divider fixed */
-  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.1);
+  display: none; /* Remove separate divider since header has border-bottom */
 }
 
 .code-tooltip-content {

--- a/frontend/src/components/CodeTooltip.css
+++ b/frontend/src/components/CodeTooltip.css
@@ -7,10 +7,11 @@
   z-index: 1000;
   max-width: 850px; /* ~100 chars at 13px font + padding (100 * 8.5px ≈ 850px) */
   max-height: 300px;
-  overflow: auto;
   transform: translateY(-100%); /* Remove X centering, align to left edge */
   font-family: var(--vscode-editor-font-family);
   animation: tooltip-appear 0.15s ease-out;
+  display: flex;
+  flex-direction: column;
 }
 
 @keyframes tooltip-appear {
@@ -24,34 +25,57 @@
   }
 }
 
+.code-tooltip-header {
+  padding: 8px 12px 6px 12px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--vscode-descriptionForeground);
+  background: var(--vscode-quickInput-background);
+  flex-shrink: 0; /* Keep header fixed */
+  border-radius: 4px 4px 0 0;
+}
+
+.code-tooltip-divider {
+  height: 1px;
+  background: var(--vscode-panel-border, #464647);
+  margin: 0;
+  flex-shrink: 0; /* Keep divider fixed */
+  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.1);
+}
+
 .code-tooltip-content {
   padding: 8px 12px;
+  overflow: auto; /* Make content scrollable */
+  flex: 1; /* Take remaining space */
 }
 
 
 
-/* .path-text {
-  font-size: 13px;
-  color: var(--vscode-foreground);
-  line-height: 1.4;
-  word-break: break-all;
-} */
 
-/* Scrollbar styling */
-.code-tooltip::-webkit-scrollbar {
+/* Scrollbar styling for tooltip content */
+.code-tooltip-content::-webkit-scrollbar,
+.code-block::-webkit-scrollbar,
+.path-text::-webkit-scrollbar {
   width: 8px;
+  height: 8px;
 }
 
-.code-tooltip::-webkit-scrollbar-track {
+.code-tooltip-content::-webkit-scrollbar-track,
+.code-block::-webkit-scrollbar-track,
+.path-text::-webkit-scrollbar-track {
   background: var(--vscode-scrollbarSlider-background);
 }
 
-.code-tooltip::-webkit-scrollbar-thumb {
+.code-tooltip-content::-webkit-scrollbar-thumb,
+.code-block::-webkit-scrollbar-thumb,
+.path-text::-webkit-scrollbar-thumb {
   background: var(--vscode-scrollbarSlider-hoverBackground);
   border-radius: 4px;
 }
 
-.code-tooltip::-webkit-scrollbar-thumb:hover {
+.code-tooltip-content::-webkit-scrollbar-thumb:hover,
+.code-block::-webkit-scrollbar-thumb:hover,
+.path-text::-webkit-scrollbar-thumb:hover {
   background: var(--vscode-scrollbarSlider-activeBackground);
 }
 
@@ -59,13 +83,23 @@
 .code-block {
   display: block;
   overflow-x: auto;
+  overflow-y: auto;
   padding: 0.5em;
   margin: 0;
   font-family: var(--vscode-editor-font-family);
   font-size: var(--vscode-editor-font-size, 13px);
   line-height: 1.4;
-  white-space: pre-wrap;
-  word-break: break-word;
+  white-space: pre; /* Prevent line wrapping */
   background: transparent; /* Use CodeTooltip background */
+  min-width: 0; /* Allow shrinking */
+}
+
+.path-text {
+  font-size: 13px;
+  color: var(--vscode-foreground);
+  line-height: 1.4;
+  overflow-x: auto;
+  white-space: nowrap; /* Prevent wrapping for paths */
+  word-break: normal;
 }
 

--- a/frontend/src/components/CodeTooltip.tsx
+++ b/frontend/src/components/CodeTooltip.tsx
@@ -130,6 +130,10 @@ export const CodeTooltip: React.FC<CodeTooltipProps> = ({
           onMouseEnter={handleTooltipMouseEnter}
           onMouseLeave={handleTooltipMouseLeave}
         >
+          <div className="code-tooltip-header">
+            {isCode ? "Node's Translated Code" : "Node Path"}
+          </div>
+          <div className="code-tooltip-divider"></div>
           <div className="code-tooltip-content">
             {isCode ? (
               <pre 

--- a/frontend/src/components/CodeTooltip.tsx
+++ b/frontend/src/components/CodeTooltip.tsx
@@ -1,0 +1,147 @@
+import React, { useState, useRef, useEffect } from "react";
+import "./CodeTooltip.css";
+import "highlight.js/styles/default.css";
+import { highlightLuauCode } from "../utils/syntaxHighlighting";
+
+interface CodeTooltipProps {
+  isCode: boolean;
+  text: string;
+  children: React.ReactNode;
+  delay?: number;
+}
+
+export const CodeTooltip: React.FC<CodeTooltipProps> = ({
+  isCode,
+  text,
+  children,
+  delay = 20,
+}) => {
+  const [isVisible, setIsVisible] = useState(false);
+  const [position, setPosition] = useState({ x: 0, y: 0 });
+  const timeoutRef = useRef<NodeJS.Timeout>(null);
+  const triggerRef = useRef<HTMLSpanElement>(null);
+  const tooltipRef = useRef<HTMLDivElement>(null);
+
+  const handleMouseEnter = (e: React.MouseEvent) => {
+    if (!text) return;
+
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
+
+    // Capture the target element immediately before the setTimeout
+    const target = e.currentTarget as HTMLElement;
+    if (!target) return;
+
+    timeoutRef.current = setTimeout(() => {
+      try {
+        const rect = target.getBoundingClientRect();
+        const tooltipWidth = 850; // updated max-width for ~100 characters
+
+        // Align to left edge of target, clamp only if it would go off-screen
+        let x = rect.left;
+        const rightBound = x + tooltipWidth;
+        
+        // Only adjust if tooltip would go off the right edge
+        if (rightBound > window.innerWidth) {
+          x = window.innerWidth - tooltipWidth;
+        }
+        
+        // Ensure tooltip doesn't go off the left edge
+        if (x < 0) {
+          x = 0;
+        }
+
+        const newPosition = {
+          x,
+          y: rect.top - 5,
+        };
+
+        setPosition(newPosition);
+        setIsVisible(true);
+      } catch (err) {
+        // Silently handle positioning errors
+      }
+    }, delay);
+  };
+
+  const handleMouseLeave = () => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
+    // Add a small delay before hiding to allow moving to tooltip
+    timeoutRef.current = setTimeout(() => {
+      setIsVisible(false);
+    }, 100);
+  };
+
+  const handleTooltipMouseEnter = () => {
+    // Cancel hide timeout when entering tooltip
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
+  };
+
+  const handleTooltipMouseLeave = () => {
+    // Hide immediately when leaving tooltip
+    setIsVisible(false);
+  };
+
+  useEffect(() => {
+    const handleScroll = (e: Event) => {
+      const target = e.target as Node | null;
+      const inTooltip =
+        tooltipRef.current && tooltipRef.current.contains(target as Node);
+      const inTrigger =
+        triggerRef.current && triggerRef.current.contains(target as Node);
+      if (inTooltip || inTrigger) {
+        return; // ignore scrolls originating from tooltip or trigger
+      }
+      setIsVisible(false);
+    };
+
+    if (isVisible) {
+      window.addEventListener("scroll", handleScroll, true);
+      return () => {
+        window.removeEventListener("scroll", handleScroll, true);
+      };
+    }
+  }, [isVisible]);
+
+  return (
+    <>
+      <span
+        ref={triggerRef}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        style={{ display: 'inline' }}
+      >
+        {children}
+      </span>
+      
+      {isVisible && (
+        <div
+          ref={tooltipRef}
+          className="code-tooltip"
+          style={{
+            left: position.x,
+            top: position.y,
+          }}
+          onMouseEnter={handleTooltipMouseEnter}
+          onMouseLeave={handleTooltipMouseLeave}
+        >
+          <div className="code-tooltip-content">
+            {isCode ? (
+              <pre 
+                className="code-block"
+                dangerouslySetInnerHTML={{ __html: highlightLuauCode(text) }}
+              />
+            ) : (
+              <div className="path-text">{text}</div>
+            )}
+          </div>
+        </div>
+      )}
+    </>
+  );
+};

--- a/frontend/src/context/codeTranslationContext.ts
+++ b/frontend/src/context/codeTranslationContext.ts
@@ -2,8 +2,8 @@ import { createContext, useContext } from "react";
 
 interface CodeTranslation {
   codeTooltips: Record<string, string>;
-  requestCodeTooltip: (nodeValue: string, nodeKey: string) => void;
-  generateNodeId: (nodeValue: string, nodeKey: string) => string;
+  requestCodeTooltip: (nodeValue: any, nodeKey: string) => void;
+  generateNodeId: (nodeValue: any, nodeKey: string) => string;
 }
 
 export const CodeTranslationContext =
@@ -12,7 +12,7 @@ export const CodeTranslationContext =
 export const useCodeTranslationContext = () => {
   const context = useContext(CodeTranslationContext);
   if (!context) {
-    throw new Error("useCache must be used within a CacheProvider");
+    throw new Error("useCodeTranslationContext must be used within a CodeTranslationProvider");
   }
   return context;
 };

--- a/frontend/src/context/codeTranslationContext.ts
+++ b/frontend/src/context/codeTranslationContext.ts
@@ -1,13 +1,13 @@
 import { createContext, useContext } from "react";
 
-interface CodeTranslationContext {
+interface CodeTranslation {
   codeTooltips: Record<string, string>;
   requestCodeTooltip: (nodeValue: string, nodeKey: string) => void;
   generateNodeId: (nodeValue: string, nodeKey: string) => string;
 }
 
 export const CodeTranslationContext =
-  createContext<CodeTranslationContext | null>(null);
+  createContext<CodeTranslation | null>(null);
 
 export const useCodeTranslationContext = () => {
   const context = useContext(CodeTranslationContext);

--- a/frontend/src/context/codeTranslationContext.ts
+++ b/frontend/src/context/codeTranslationContext.ts
@@ -1,0 +1,18 @@
+import { createContext, useContext } from "react";
+
+interface CodeTranslationContext {
+  codeTooltips: Record<string, string>;
+  requestCodeTooltip: (nodeValue: string, nodeKey: string) => void;
+  generateNodeId: (nodeValue: string, nodeKey: string) => string;
+}
+
+export const CodeTranslationContext =
+  createContext<CodeTranslationContext | null>(null);
+
+export const useCodeTranslationContext = () => {
+  const context = useContext(CodeTranslationContext);
+  if (!context) {
+    throw new Error("useCache must be used within a CacheProvider");
+  }
+  return context;
+};

--- a/frontend/src/hooks/useCodeTooltip.ts
+++ b/frontend/src/hooks/useCodeTooltip.ts
@@ -42,8 +42,8 @@ export const useCodeTooltip = (vscodeApi: VSCodeAPI | null) => {
   const handlePrintCodeResult = useCallback((message: any) => {
     if (message.command === "printCodeResult") {
       const { nodeId, status, code, error } = message;
-
-      if (status === "success" && code) {
+      const emptyCode = code && code.trim() === "";
+      if (status === "success" && !emptyCode) {
         console.log("Success! Setting code tooltip for nodeId:", nodeId);
         setCodeTooltips((prev) => ({
           ...prev,
@@ -54,7 +54,7 @@ export const useCodeTooltip = (vscodeApi: VSCodeAPI | null) => {
           ...prev,
           [nodeId]: "Loading...",
         }));
-      } else if (status === "error") {
+      } else if (status === "error" || emptyCode) {
         console.log("Error for nodeId:", nodeId, "error:", error);
         // remove nodeId from from codeTooltips
         setCodeTooltips((prev) => {
@@ -73,4 +73,3 @@ export const useCodeTooltip = (vscodeApi: VSCodeAPI | null) => {
     generateNodeId,
   };
 };
-

--- a/frontend/src/hooks/useCodeTooltip.ts
+++ b/frontend/src/hooks/useCodeTooltip.ts
@@ -1,88 +1,83 @@
-import { useState, useCallback, useRef } from 'react';
-import { VSCodeAPI, PrintCodeMessage } from '../typesAndInterfaces';
+import { useState, useCallback, useRef } from "react";
+import { VSCodeAPI, PrintCodeMessage } from "../typesAndInterfaces";
 
 export const useCodeTooltip = (vscodeApi: VSCodeAPI | null) => {
   const [codeTooltips, setCodeTooltips] = useState<Record<string, string>>({});
-  const [loadingNodes, setLoadingNodes] = useState<Set<string>>(new Set());
   const requestedNodes = useRef<Set<string>>(new Set());
 
-  const generateNodeId = useCallback((nodeValue: any, nodeKey: string): string => {
-    // Create a stable ID based on node content
-    const content = JSON.stringify(nodeValue);
-    const hash = content.length.toString() + content.substring(0, 30).replace(/[^a-zA-Z0-9]/g, '');
-    return `${nodeKey}_${hash}`;
-  }, []);
+  const generateNodeId = useCallback(
+    (nodeValue: any, nodeKey: string): string => {
+      // Create a stable ID based on node content
+      const content = JSON.stringify(nodeValue);
+      const hash =
+        content.length.toString() +
+        content.substring(0, 20).replace(/[^a-zA-Z0-9]/g, "");
+      return `${nodeKey}_${hash}`;
+    },
+    []
+  );
 
-  const requestCodeTooltip = useCallback((nodeValue: any, nodeKey: string) => {
-    if (!vscodeApi || !nodeValue?.tag) return;
+  const requestCodeTooltip = useCallback(
+    (nodeValue: any, nodeKey: string) => {
+      if (!vscodeApi || !nodeValue?.tag) return;
 
-    const nodeId = generateNodeId(nodeValue, nodeKey);
-    
-    // Don't request if already requested/loading or cached
-    if (requestedNodes.current.has(nodeId) || codeTooltips[nodeId]) return;
+      const nodeId = generateNodeId(nodeValue, nodeKey);
 
-    requestedNodes.current.add(nodeId);
-    setLoadingNodes(prev => new Set(prev).add(nodeId));
+      // Don't request if already requested/loading or cached
+      if (requestedNodes.current.has(nodeId) || codeTooltips[nodeId]) return;
 
-    const message: PrintCodeMessage = {
-      command: "printCode",
-      nodeJson: JSON.stringify(nodeValue),
-      nodeId: nodeId
-    };
+      console.log(
+        "Frontend requesting code for nodeId:",
+        nodeId,
+        "nodeKey:",
+        nodeKey
+      );
+      requestedNodes.current.add(nodeId);
 
-    vscodeApi.postMessage(message);
-  }, [vscodeApi, generateNodeId, codeTooltips]);
+      const message: PrintCodeMessage = {
+        command: "printCode",
+        nodeJson: JSON.stringify(nodeValue),
+        nodeId: nodeId,
+      };
+
+      vscodeApi.postMessage(message);
+    },
+    [vscodeApi, generateNodeId, codeTooltips]
+  );
 
   const handlePrintCodeResult = useCallback((message: any) => {
+    console.log("Frontend received printCodeResult:", message);
     if (message.command === "printCodeResult") {
       const { nodeId, status, code, error } = message;
-      
-      setLoadingNodes(prev => {
-        const newSet = new Set(prev);
-        newSet.delete(nodeId);
-        return newSet;
-      });
 
       if (status === "success" && code) {
-        setCodeTooltips(prev => ({
+        console.log("Setting code tooltip for nodeId:", nodeId, "code:", code);
+        setCodeTooltips((prev) => ({
           ...prev,
-          [nodeId]: code.trim()
+          [nodeId]: code.trim(),
+        }));
+      } else if (status === "loading") {
+        setCodeTooltips((prev) => ({
+          ...prev,
+          [nodeId]: "Loading...",
         }));
       } else if (status === "error") {
-        setCodeTooltips(prev => ({
-          ...prev,
-          [nodeId]: `Error: ${error || 'Failed to print code'}`
-        }));
+        console.log("Error for nodeId:", nodeId, "error:", error);
+        // remove nodeId from from codeTooltips
+        setCodeTooltips((prev) => {
+          const newTooltips = { ...prev };
+          delete newTooltips[nodeId];
+          return newTooltips;
+        });
       }
     }
   }, []);
 
-  const getTooltipContent = useCallback((nodeValue: any, nodeKey: string, fallbackPath: string): string => {
-    // If this is an object with a tag, try to get/request code tooltip
-    if (nodeValue && typeof nodeValue === 'object' && !Array.isArray(nodeValue) && nodeValue.tag) {
-      const nodeId = generateNodeId(nodeValue, nodeKey);
-      
-      // If we have a cached result, return it
-      if (codeTooltips[nodeId]) {
-        return codeTooltips[nodeId];
-      }
-      
-      // If we're loading, show loading message
-      if (loadingNodes.has(nodeId)) {
-        return "Loading code...";
-      }
-      
-      // Otherwise, request the code and show path for now
-      requestCodeTooltip(nodeValue, nodeKey);
-      return fallbackPath;
-    }
-    
-    // Fallback to path tooltip for non-tag nodes
-    return fallbackPath;
-  }, [generateNodeId, codeTooltips, loadingNodes, requestCodeTooltip]);
-
   return {
-    getTooltipContent,
-    handlePrintCodeResult
+    handlePrintCodeResult,
+    requestCodeTooltip,
+    codeTooltips,
+    generateNodeId,
   };
 };
+

--- a/frontend/src/hooks/useCodeTooltip.ts
+++ b/frontend/src/hooks/useCodeTooltip.ts
@@ -47,7 +47,7 @@ export const useCodeTooltip = (vscodeApi: VSCodeAPI | null) => {
         console.log("Success! Setting code tooltip for nodeId:", nodeId);
         setCodeTooltips((prev) => ({
           ...prev,
-          [nodeId]: code.trim(),
+          [nodeId]: code,
         }));
       } else if (status === "loading") {
         setCodeTooltips((prev) => ({

--- a/frontend/src/hooks/useCodeTooltip.ts
+++ b/frontend/src/hooks/useCodeTooltip.ts
@@ -26,12 +26,6 @@ export const useCodeTooltip = (vscodeApi: VSCodeAPI | null) => {
       // Don't request if already requested/loading or cached
       if (requestedNodes.current.has(nodeId) || codeTooltips[nodeId]) return;
 
-      console.log(
-        "Frontend requesting code for nodeId:",
-        nodeId,
-        "nodeKey:",
-        nodeKey
-      );
       requestedNodes.current.add(nodeId);
 
       const message: PrintCodeMessage = {
@@ -46,12 +40,11 @@ export const useCodeTooltip = (vscodeApi: VSCodeAPI | null) => {
   );
 
   const handlePrintCodeResult = useCallback((message: any) => {
-    console.log("Frontend received printCodeResult:", message);
     if (message.command === "printCodeResult") {
       const { nodeId, status, code, error } = message;
 
       if (status === "success" && code) {
-        console.log("Setting code tooltip for nodeId:", nodeId, "code:", code);
+        console.log("Success! Setting code tooltip for nodeId:", nodeId);
         setCodeTooltips((prev) => ({
           ...prev,
           [nodeId]: code.trim(),

--- a/frontend/src/hooks/useCodeTooltip.ts
+++ b/frontend/src/hooks/useCodeTooltip.ts
@@ -19,7 +19,7 @@ export const useCodeTooltip = (vscodeApi: VSCodeAPI | null) => {
 
   const requestCodeTooltip = useCallback(
     (nodeValue: any, nodeKey: string) => {
-      if (!vscodeApi || !nodeValue?.tag) return;
+      if (!vscodeApi) return;
 
       const nodeId = generateNodeId(nodeValue, nodeKey);
 

--- a/frontend/src/hooks/useCodeTooltip.ts
+++ b/frontend/src/hooks/useCodeTooltip.ts
@@ -1,0 +1,88 @@
+import { useState, useCallback, useRef } from 'react';
+import { VSCodeAPI, PrintCodeMessage } from '../typesAndInterfaces';
+
+export const useCodeTooltip = (vscodeApi: VSCodeAPI | null) => {
+  const [codeTooltips, setCodeTooltips] = useState<Record<string, string>>({});
+  const [loadingNodes, setLoadingNodes] = useState<Set<string>>(new Set());
+  const requestedNodes = useRef<Set<string>>(new Set());
+
+  const generateNodeId = useCallback((nodeValue: any, nodeKey: string): string => {
+    // Create a stable ID based on node content
+    const content = JSON.stringify(nodeValue);
+    const hash = content.length.toString() + content.substring(0, 30).replace(/[^a-zA-Z0-9]/g, '');
+    return `${nodeKey}_${hash}`;
+  }, []);
+
+  const requestCodeTooltip = useCallback((nodeValue: any, nodeKey: string) => {
+    if (!vscodeApi || !nodeValue?.tag) return;
+
+    const nodeId = generateNodeId(nodeValue, nodeKey);
+    
+    // Don't request if already requested/loading or cached
+    if (requestedNodes.current.has(nodeId) || codeTooltips[nodeId]) return;
+
+    requestedNodes.current.add(nodeId);
+    setLoadingNodes(prev => new Set(prev).add(nodeId));
+
+    const message: PrintCodeMessage = {
+      command: "printCode",
+      nodeJson: JSON.stringify(nodeValue),
+      nodeId: nodeId
+    };
+
+    vscodeApi.postMessage(message);
+  }, [vscodeApi, generateNodeId, codeTooltips]);
+
+  const handlePrintCodeResult = useCallback((message: any) => {
+    if (message.command === "printCodeResult") {
+      const { nodeId, status, code, error } = message;
+      
+      setLoadingNodes(prev => {
+        const newSet = new Set(prev);
+        newSet.delete(nodeId);
+        return newSet;
+      });
+
+      if (status === "success" && code) {
+        setCodeTooltips(prev => ({
+          ...prev,
+          [nodeId]: code.trim()
+        }));
+      } else if (status === "error") {
+        setCodeTooltips(prev => ({
+          ...prev,
+          [nodeId]: `Error: ${error || 'Failed to print code'}`
+        }));
+      }
+    }
+  }, []);
+
+  const getTooltipContent = useCallback((nodeValue: any, nodeKey: string, fallbackPath: string): string => {
+    // If this is an object with a tag, try to get/request code tooltip
+    if (nodeValue && typeof nodeValue === 'object' && !Array.isArray(nodeValue) && nodeValue.tag) {
+      const nodeId = generateNodeId(nodeValue, nodeKey);
+      
+      // If we have a cached result, return it
+      if (codeTooltips[nodeId]) {
+        return codeTooltips[nodeId];
+      }
+      
+      // If we're loading, show loading message
+      if (loadingNodes.has(nodeId)) {
+        return "Loading code...";
+      }
+      
+      // Otherwise, request the code and show path for now
+      requestCodeTooltip(nodeValue, nodeKey);
+      return fallbackPath;
+    }
+    
+    // Fallback to path tooltip for non-tag nodes
+    return fallbackPath;
+  }, [generateNodeId, codeTooltips, loadingNodes, requestCodeTooltip]);
+
+  return {
+    getTooltipContent,
+    handlePrintCodeResult
+  };
+};

--- a/frontend/src/hooks/useCodeTranslation.ts
+++ b/frontend/src/hooks/useCodeTranslation.ts
@@ -1,7 +1,7 @@
 import { useState, useCallback, useRef } from "react";
 import { VSCodeAPI, PrintCodeMessage } from "../typesAndInterfaces";
 
-export const useCodeTooltip = (vscodeApi: VSCodeAPI | null) => {
+export const useCodeTranslation = (vscodeApi: VSCodeAPI | null) => {
   const [codeTooltips, setCodeTooltips] = useState<Record<string, string>>({});
   const requestedNodes = useRef<Set<string>>(new Set());
 

--- a/frontend/src/hooks/useCodeTranslation.ts
+++ b/frontend/src/hooks/useCodeTranslation.ts
@@ -11,7 +11,7 @@ export const useCodeTranslation = (vscodeApi: VSCodeAPI | null) => {
       const content = JSON.stringify(nodeValue);
       const hash =
         content.length.toString() +
-        content.substring(0, 20).replace(/[^a-zA-Z0-9]/g, "");
+        content.substring(0, 25).replace(/[^a-zA-Z0-9]/g, "");
       return `${nodeKey}_${hash}`;
     },
     []

--- a/frontend/src/tests/syntaxHighlighting.test.ts
+++ b/frontend/src/tests/syntaxHighlighting.test.ts
@@ -1,0 +1,39 @@
+// Mock the CSS import
+jest.mock('../utils/syntaxHighlighting.css', () => ({}));
+
+import { detectVSCodeTheme, hexToRGB } from "../utils/syntaxHighlighting";
+
+const light: [string, [number, number, number]][] = [
+    ["#ffffff", [255, 255, 255]],
+    ["ffffff", [255, 255, 255]],
+    ["#f5f5f5", [245, 245, 245]],
+    ["f0f0f0", [240, 240, 240]],
+    ["#eaeaea", [234, 234, 234]],
+];
+const dark: [string, [number, number, number]][] = [
+    ["#000000", [0, 0, 0]],
+    ["000000", [0, 0, 0]],
+    ["#1a1a1a", [26, 26, 26]],
+    ["222222", [34, 34, 34]],
+    ["#2d2d2d", [45, 45, 45]],
+];
+
+describe("syntaxHighlighting", () => {
+    test("hexToRGB", () => {
+        light.forEach((hex) => {
+            expect(hexToRGB(hex[0])).toStrictEqual(hex[1]);
+        });
+        dark.forEach((hex) => {
+            expect(hexToRGB(hex[0])).toStrictEqual(hex[1]);
+        })
+    });
+
+    test("detectVSCodeTheme", () => {
+        light.forEach((hex) => {
+            expect(detectVSCodeTheme(hex[0])).toBe('light');
+        });
+        dark.forEach((hex) => {
+            expect(detectVSCodeTheme(hex[0])).toBe('dark');
+        });
+    });
+});

--- a/frontend/src/typesAndInterfaces.ts
+++ b/frontend/src/typesAndInterfaces.ts
@@ -73,6 +73,20 @@ export interface JsonDiffChange {
   changes?: JsonDiffChange[]; // For nested changes
 }
 
+export interface PrintCodeMessage {
+  command: "printCode";
+  nodeJson: string;
+  nodeId: string;
+}
+
+export interface PrintCodeResultMessage {
+  command: "printCodeResult";
+  status: "loading" | "success" | "error";
+  nodeId: string;
+  code?: string;
+  error?: string;
+}
+
 export enum WindowMode {
   Explorer = "explorer", // Current AST viewer (default)
   LiveEditor = "live-editor", // Window 1: Live code editor + AST

--- a/frontend/src/utils/astTypeHelpers.ts
+++ b/frontend/src/utils/astTypeHelpers.ts
@@ -140,9 +140,6 @@ export const getTypeString = (
       nodeKey === "entries" ? value : undefined
     );
   }
-  if (parentInferredType !== type) {
-    console.log("type:", type, "vs. parentInferredType:", parentInferredType);
-  }
   type = !type ? parentInferredType : type; // if type is null, fallback to parentInferredType (this should handle Punctuated well)
   return [type, kind];
 };

--- a/frontend/src/utils/syntaxHighlighting.css
+++ b/frontend/src/utils/syntaxHighlighting.css
@@ -1,0 +1,153 @@
+/* DARK THEME COLORS - Atom One Dark theme with proper selectors */
+.dark .hljs {
+    color: #abb2bf;
+    background: transparent;
+}
+
+/* Comments */
+.dark .hljs-comment,
+.dark .hljs-quote {
+    color: #5c6370;
+    font-style: italic;
+}
+
+/* Keywords - Purple */
+.dark .hljs-keyword,
+.dark .hljs-selector-tag {
+    color: #c678dd;
+    font-weight: 500;
+}
+
+/* Function titles and sections - Blue */
+.dark .hljs-title,
+.dark .hljs-section {
+    color: #61aeee;
+}
+
+/* Strings and symbols - Green */
+.dark .hljs-string,
+.dark .hljs-symbol,
+.dark .hljs-bullet,
+.dark .hljs-addition {
+    color: #98c379;
+}
+
+/* Numbers, built-ins, literals, types, params - Orange */
+.dark .hljs-number,
+.dark .hljs-built_in,
+.dark .hljs-literal,
+.dark .hljs-type,
+.dark .hljs-params,
+.dark .hljs-meta,
+.dark .hljs-link {
+    color: #d19a66;
+}
+
+/* Attributes - Orange */
+.dark .hljs-attribute {
+    color: #d19a66;
+}
+
+/* Variables, template variables, tags, names, selectors - Red */
+.dark .hljs-variable,
+.dark .hljs-template-variable,
+.dark .hljs-tag,
+.dark .hljs-name,
+.dark .hljs-selector-id,
+.dark .hljs-selector-class,
+.dark .hljs-regexp,
+.dark .hljs-deletion {
+    color: #e06c75;
+}
+
+/* Types and class titles - Yellow */
+.dark .hljs-title.class_,
+.dark .hljs-class .hljs-title {
+    color: #e6c07b;
+}
+
+/* Emphasis */
+.dark .hljs-emphasis {
+    font-style: italic;
+}
+
+.dark .hljs-strong {
+    font-weight: bold;
+}
+
+/* LIGHT THEME COLORS - Atom One Light theme with proper selectors */
+.light .hljs {
+    color: #383a42;
+    background: transparent;
+}
+
+/* Comments */
+.light .hljs-comment,
+.light .hljs-quote {
+    color: #a0a1a7;
+    font-style: italic;
+}
+
+/* Keywords - Purple */
+.light .hljs-keyword,
+.light .hljs-selector-tag {
+    color: #a626a4;
+    font-weight: 500;
+}
+
+/* Function titles and sections - Blue */
+.light .hljs-title,
+.light .hljs-section {
+    color: #4078f2;
+}
+
+/* Strings and symbols - Green */
+.light .hljs-string,
+.light .hljs-symbol,
+.light .hljs-bullet,
+.light .hljs-addition {
+    color: #50a14f;
+}
+
+/* Numbers, built-ins, literals, types, params - Orange */
+.light .hljs-number,
+.light .hljs-built_in,
+.light .hljs-literal,
+.light .hljs-type,
+.light .hljs-params,
+.light .hljs-meta,
+.light .hljs-link {
+    color: #986801;
+}
+
+/* Attributes - Orange */
+.light .hljs-attribute {
+    color: #986801;
+}
+
+/* Variables, template variables, tags, names, selectors - Red */
+.light .hljs-variable,
+.light .hljs-template-variable,
+.light .hljs-tag,
+.light .hljs-name,
+.light .hljs-selector-id,
+.light .hljs-selector-class,
+.light .hljs-regexp,
+.light .hljs-deletion {
+    color: #e45649;
+}
+
+/* Types and class titles - Yellow */
+.light .hljs-title.class_,
+.light .hljs-class .hljs-title {
+    color: #c18401;
+}
+
+/* Emphasis */
+.light .hljs-emphasis {
+    font-style: italic;
+}
+
+.light .hljs-strong {
+    font-weight: bold;
+}

--- a/frontend/src/utils/syntaxHighlighting.css
+++ b/frontend/src/utils/syntaxHighlighting.css
@@ -75,30 +75,30 @@
     font-weight: bold;
 }
 
-/* LIGHT THEME COLORS - Atom One Light theme with proper selectors */
+/* LIGHT THEME COLORS - Darker Atom One Light theme with proper selectors */
 .light .hljs {
-    color: #383a42;
+    color: #2c2d30;
     background: transparent;
 }
 
 /* Comments */
 .light .hljs-comment,
 .light .hljs-quote {
-    color: #a0a1a7;
+    color: #7d7e84;
     font-style: italic;
 }
 
 /* Keywords - Purple */
 .light .hljs-keyword,
 .light .hljs-selector-tag {
-    color: #a626a4;
+    color: #8b1a89;
     font-weight: 500;
 }
 
 /* Function titles and sections - Blue */
 .light .hljs-title,
 .light .hljs-section {
-    color: #4078f2;
+    color: #2c5cc5;
 }
 
 /* Strings and symbols - Green */
@@ -106,7 +106,7 @@
 .light .hljs-symbol,
 .light .hljs-bullet,
 .light .hljs-addition {
-    color: #50a14f;
+    color: #3d8b40;
 }
 
 /* Numbers, built-ins, literals, types, params - Orange */
@@ -117,12 +117,12 @@
 .light .hljs-params,
 .light .hljs-meta,
 .light .hljs-link {
-    color: #986801;
+    color: #7a5500;
 }
 
 /* Attributes - Orange */
 .light .hljs-attribute {
-    color: #986801;
+    color: #7a5500;
 }
 
 /* Variables, template variables, tags, names, selectors - Red */
@@ -134,13 +134,13 @@
 .light .hljs-selector-class,
 .light .hljs-regexp,
 .light .hljs-deletion {
-    color: #e45649;
+    color: #c4374a;
 }
 
 /* Types and class titles - Yellow */
 .light .hljs-title.class_,
 .light .hljs-class .hljs-title {
-    color: #c18401;
+    color: #a06f00;
 }
 
 /* Emphasis */

--- a/frontend/src/utils/syntaxHighlighting.ts
+++ b/frontend/src/utils/syntaxHighlighting.ts
@@ -1,10 +1,102 @@
 import hljs from 'highlight.js/lib/core';
 // @ts-ignore - Package has no type definitions
 import luau from 'highlightjs-luau';
-import "highlight.js/styles/atom-one-dark.css"
+// Import our custom CSS with both light and dark themes
+import './syntaxHighlighting.css';
 
 // Register the Luau language
 hljs.registerLanguage('luau', luau);
+
+/**
+ * Applies the appropriate highlight.js theme class based on VS Code theme
+ */
+function applyThemeClass(): void {
+  const theme = detectVSCodeTheme();
+  console.log("Detected VS Code theme:", theme);
+  
+  // Remove existing theme classes
+  document.body.classList.remove('dark', 'light');
+  
+  // Apply appropriate theme class
+  const themeClass = theme === 'light' ? 'light' : 'dark';
+  document.body.classList.add(themeClass);
+  console.log("Applied theme class:", themeClass);
+}
+
+/**
+ * Refreshes the highlight.js theme based on current VS Code theme
+ * Call this when you detect a theme change
+ */
+export function refreshHighlightTheme(): void {
+  applyThemeClass();
+}
+
+// Initialize theme on module load
+applyThemeClass();
+
+// Listen for theme changes
+if (typeof window !== 'undefined') {
+  // Listen for storage events (VS Code might use localStorage for theme changes)
+  window.addEventListener('storage', refreshHighlightTheme);
+  
+  // Listen for color scheme changes
+  const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+  mediaQuery.addEventListener('change', refreshHighlightTheme);
+}
+
+/**
+ * Detects if the current VS Code theme is dark or light
+ * @returns 'dark' | 'light' | 'unknown'
+ */
+export function detectVSCodeTheme(): 'dark' | 'light' | 'unknown' {
+  try {
+    // Method 1: Check VS Code CSS variable for editor background
+    const editorBg = getComputedStyle(document.documentElement)
+      .getPropertyValue('--vscode-editor-background').trim();
+    
+    if (editorBg) {
+      const luminance = getLuminanceFromColor(editorBg);
+      return luminance < 0.5 ? 'dark' : 'light';
+    }
+
+    return 'unknown';
+  } catch (error) {
+    console.warn('Failed to detect VS Code theme:', error);
+    return 'unknown';
+  }
+}
+
+/**
+ * Calculates the relative luminance of a color
+ * @param color - CSS color string (hex, rgb, rgba)
+ * @returns luminance value between 0 (dark) and 1 (light)
+ */
+function getLuminanceFromColor(color: string): number {
+  try {
+    const div = document.createElement('div');
+    div.style.color = color;
+    document.body.appendChild(div);
+    
+    const computedColor = getComputedStyle(div).color;
+    document.body.removeChild(div);
+    
+    const rgbMatch = computedColor.match(/rgb\((\d+),\s*(\d+),\s*(\d+)\)/);
+    if (!rgbMatch) return 0.5;
+    
+    const [, r, g, b] = rgbMatch.map(Number);
+    
+    const getRGBLuminance = (val: number) => {
+      const normalized = val / 255;
+      return normalized <= 0.03928 
+        ? normalized / 12.92 
+        : Math.pow((normalized + 0.055) / 1.055, 2.4);
+    };
+    
+    return 0.2126 * getRGBLuminance(r) + 0.7152 * getRGBLuminance(g) + 0.0722 * getRGBLuminance(b);
+  } catch (error) {
+    return 0.5;
+  }
+}
 
 /**
  * Escapes HTML in a string
@@ -25,16 +117,13 @@ function escapeHtml(text: string): string {
  */
 export function highlightLuauCode(code: string): string {
   try {
-    // Use proper Luau highlighting from highlightjs-luau package
     const result = hljs.highlight(code, { language: 'luau' });
     return result.value;
   } catch (error) {
-    // Fallback to auto-detection if Luau highlighting fails
     try {
       const result = hljs.highlightAuto(code, ['luau', 'lua', 'javascript']);
       return result.value;
     } catch (fallbackError) {
-      // If all highlighting fails, return the original code escaped
       return escapeHtml(code);
     }
   }

--- a/frontend/src/utils/syntaxHighlighting.ts
+++ b/frontend/src/utils/syntaxHighlighting.ts
@@ -1,11 +1,11 @@
 import hljs from 'highlight.js/lib/core';
+import lua from "highlight.js/lib/languages/lua"
 // @ts-ignore - Package has no type definitions
-import luau from 'highlightjs-luau';
 // Import our custom CSS with both light and dark themes
 import './syntaxHighlighting.css';
 
 // Register the Luau language
-hljs.registerLanguage('luau', luau);
+hljs.registerLanguage('lua', lua);
 
 /**
  * Applies the appropriate highlight.js theme class based on VS Code theme
@@ -117,7 +117,7 @@ function escapeHtml(text: string): string {
  */
 export function highlightLuauCode(code: string): string {
   try {
-    const result = hljs.highlight(code, { language: 'luau' });
+    const result = hljs.highlight(code, { language: 'lua' });
     return result.value;
   } catch (error) {
     try {

--- a/frontend/src/utils/syntaxHighlighting.ts
+++ b/frontend/src/utils/syntaxHighlighting.ts
@@ -46,7 +46,7 @@ try {
     mediaQuery.addEventListener("change", refreshHighlightTheme);
   }
 } catch (error) {
-  console.log("Failed to add window event listeners:", error);
+  console.log("Failed to add window event listeners");
 }
 
 /**

--- a/frontend/src/utils/syntaxHighlighting.ts
+++ b/frontend/src/utils/syntaxHighlighting.ts
@@ -1,0 +1,41 @@
+import hljs from 'highlight.js/lib/core';
+// @ts-ignore - Package has no type definitions
+import luau from 'highlightjs-luau';
+import "highlight.js/styles/atom-one-dark.css"
+
+// Register the Luau language
+hljs.registerLanguage('luau', luau);
+
+/**
+ * Escapes HTML in a string
+ */
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+/**
+ * Highlights Luau code using highlightjs-luau package
+ * @param code - The Luau code to highlight
+ * @returns HTML string with syntax highlighting
+ */
+export function highlightLuauCode(code: string): string {
+  try {
+    // Use proper Luau highlighting from highlightjs-luau package
+    const result = hljs.highlight(code, { language: 'luau' });
+    return result.value;
+  } catch (error) {
+    // Fallback to auto-detection if Luau highlighting fails
+    try {
+      const result = hljs.highlightAuto(code, ['luau', 'lua', 'javascript']);
+      return result.value;
+    } catch (fallbackError) {
+      // If all highlighting fails, return the original code escaped
+      return escapeHtml(code);
+    }
+  }
+}

--- a/frontend/src/utils/syntaxHighlighting.ts
+++ b/frontend/src/utils/syntaxHighlighting.ts
@@ -1,26 +1,27 @@
-import hljs from 'highlight.js/lib/core';
-import lua from "highlight.js/lib/languages/lua"
+import hljs from "highlight.js/lib/core";
+import lua from "highlight.js/lib/languages/lua";
 // @ts-ignore - Package has no type definitions
 // Import our custom CSS with both light and dark themes
-import './syntaxHighlighting.css';
+import "./syntaxHighlighting.css";
 
 // Register the Luau language
-hljs.registerLanguage('lua', lua);
+hljs.registerLanguage("lua", lua);
 
 /**
  * Applies the appropriate highlight.js theme class based on VS Code theme
  */
 function applyThemeClass(): void {
-  const theme = detectVSCodeTheme();
-  console.log("Detected VS Code theme:", theme);
-  
+  const editorBg = getComputedStyle(document.documentElement)
+    .getPropertyValue("--vscode-editor-background")
+    .trim();
+  const theme = detectVSCodeTheme(editorBg);
+
   // Remove existing theme classes
-  document.body.classList.remove('dark', 'light');
-  
+  document.body.classList.remove("dark", "light");
+
   // Apply appropriate theme class
-  const themeClass = theme === 'light' ? 'light' : 'dark';
+  const themeClass = theme === "light" ? "light" : "dark";
   document.body.classList.add(themeClass);
-  console.log("Applied theme class:", themeClass);
 }
 
 /**
@@ -35,35 +36,59 @@ export function refreshHighlightTheme(): void {
 applyThemeClass();
 
 // Listen for theme changes
-if (typeof window !== 'undefined') {
-  // Listen for storage events (VS Code might use localStorage for theme changes)
-  window.addEventListener('storage', refreshHighlightTheme);
-  
-  // Listen for color scheme changes
-  const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
-  mediaQuery.addEventListener('change', refreshHighlightTheme);
+try {
+  if (typeof window !== "undefined") {
+    // Listen for storage events (VS Code might use localStorage for theme changes)
+    window.addEventListener("storage", refreshHighlightTheme);
+
+    // Listen for color scheme changes
+    const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+    mediaQuery.addEventListener("change", refreshHighlightTheme);
+  }
+} catch (error) {
+  console.log("Failed to add window event listeners:", error);
 }
 
 /**
  * Detects if the current VS Code theme is dark or light
  * @returns 'dark' | 'light' | 'unknown'
  */
-export function detectVSCodeTheme(): 'dark' | 'light' | 'unknown' {
+export function detectVSCodeTheme(
+  editorBgColor: string
+): "dark" | "light" | "unknown" {
   try {
     // Method 1: Check VS Code CSS variable for editor background
-    const editorBg = getComputedStyle(document.documentElement)
-      .getPropertyValue('--vscode-editor-background').trim();
-    
-    if (editorBg) {
-      const luminance = getLuminanceFromColor(editorBg);
-      return luminance < 0.5 ? 'dark' : 'light';
+    if (editorBgColor) {
+      const luminance = getLuminanceFromColor(editorBgColor);
+      return luminance < 0.5 ? "dark" : "light";
     }
 
-    return 'unknown';
+    return "unknown";
   } catch (error) {
-    console.warn('Failed to detect VS Code theme:', error);
-    return 'unknown';
+    console.warn("Failed to detect VS Code theme:", error);
+    return "unknown";
   }
+}
+
+export function hexToRGB(hex: string) {
+  hex = hex.replace("#", "");
+
+  let cleanHex = hex.startsWith("#") ? hex.slice(1) : hex;
+
+  // Expand shorthand hex (e.g., "F00" to "FF0000")
+  if (cleanHex.length === 3) {
+    cleanHex = cleanHex
+      .split("")
+      .map((char) => char + char)
+      .join("");
+  }
+
+  // Parse R, G, B components
+  const r = parseInt(cleanHex.substring(0, 2), 16);
+  const g = parseInt(cleanHex.substring(2, 4), 16);
+  const b = parseInt(cleanHex.substring(4, 6), 16);
+
+  return [r, g, b];
 }
 
 /**
@@ -73,26 +98,20 @@ export function detectVSCodeTheme(): 'dark' | 'light' | 'unknown' {
  */
 function getLuminanceFromColor(color: string): number {
   try {
-    const div = document.createElement('div');
-    div.style.color = color;
-    document.body.appendChild(div);
-    
-    const computedColor = getComputedStyle(div).color;
-    document.body.removeChild(div);
-    
-    const rgbMatch = computedColor.match(/rgb\((\d+),\s*(\d+),\s*(\d+)\)/);
-    if (!rgbMatch) return 0.5;
-    
-    const [, r, g, b] = rgbMatch.map(Number);
-    
+    const [r, g, b] = hexToRGB(color);
+
     const getRGBLuminance = (val: number) => {
       const normalized = val / 255;
-      return normalized <= 0.03928 
-        ? normalized / 12.92 
+      return normalized <= 0.03928
+        ? normalized / 12.92
         : Math.pow((normalized + 0.055) / 1.055, 2.4);
     };
-    
-    return 0.2126 * getRGBLuminance(r) + 0.7152 * getRGBLuminance(g) + 0.0722 * getRGBLuminance(b);
+
+    return (
+      0.2126 * getRGBLuminance(r) +
+      0.7152 * getRGBLuminance(g) +
+      0.0722 * getRGBLuminance(b)
+    );
   } catch (error) {
     return 0.5;
   }
@@ -103,11 +122,11 @@ function getLuminanceFromColor(color: string): number {
  */
 function escapeHtml(text: string): string {
   return text
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;');
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
 }
 
 /**
@@ -117,11 +136,11 @@ function escapeHtml(text: string): string {
  */
 export function highlightLuauCode(code: string): string {
   try {
-    const result = hljs.highlight(code, { language: 'lua' });
+    const result = hljs.highlight(code, { language: "lua" });
     return result.value;
   } catch (error) {
     try {
-      const result = hljs.highlightAuto(code, ['luau', 'lua', 'javascript']);
+      const result = hljs.highlightAuto(code, ["luau", "lua", "javascript"]);
       return result.value;
     } catch (fallbackError) {
       return escapeHtml(code);

--- a/lua_helpers/ast_json_to_code.luau
+++ b/lua_helpers/ast_json_to_code.luau
@@ -17,6 +17,8 @@ local sourceCode = fs.readfiletostring(sourceFilePath)
 local astNode = json.decode(sourceCode)
 
 local code
+-- once printStatement functionality is added, this will work even better
+-- we can just try printstatement, if fail, try printexpr and it will catch many more cases
 if astNode.tag == "block" then
     code = printer.print(astNode)
 else

--- a/lua_helpers/ast_json_to_code.luau
+++ b/lua_helpers/ast_json_to_code.luau
@@ -1,0 +1,25 @@
+local fs = require("@lute/fs")
+local printer = require("@std/syntax/printer")
+local json = require("./json")
+
+-- Get the source file path from command line argument
+local args = { ... }
+
+if #args < 1 then
+	error("Usage: lute run ast_json_to_code.luau <source_file_path>")
+end
+
+local sourceFilePath = args[2]
+
+-- Read the source code from file
+local sourceCode = fs.readfiletostring(sourceFilePath)
+
+local astNode = json.decode(sourceCode)
+
+local code
+if astNode.tag == "block" then
+    code = printer.print(astNode)
+else
+    code = printer.printexpr(astNode)
+end
+print(code)

--- a/lua_helpers/ast_json_to_code.luau
+++ b/lua_helpers/ast_json_to_code.luau
@@ -26,7 +26,18 @@ if not success then
 		return printer.printexpr(astNode)
 	end)
 end
--- want to have nicely formatted code, so output to tmp file, run stylua on it, then output formatted contents
+if not success then
+	if string.find(astNode._astType, "Token") then
+		success, code = pcall(function()
+			return printer.printtoken(astNode)
+		end)
+	else
+		success, code = pcall(function()
+			return printer.printlocal(astNode)
+		end)
+	end
+end
+
 if success then
 	-- stylua it
 	fs.writestringtofile(sourceFilePath, code)

--- a/lua_helpers/ast_json_to_code.luau
+++ b/lua_helpers/ast_json_to_code.luau
@@ -1,6 +1,7 @@
 local fs = require("@lute/fs")
 local printer = require("./temp_vendor/lute_printer") -- temp vendoring printer until my updates to support printStatement are released
 local json = require("./json")
+local process = require("@lute/process")
 
 -- Get the source file path from command line argument
 local args = { ... }
@@ -21,6 +22,15 @@ success, code = pcall(function()
 	return printer.printstatement(astNode)
 end)
 if not success then
-	code = printer.printexpr(astNode)
+	success, code = pcall(function()
+		return printer.printexpr(astNode)
+	end)
+end
+-- want to have nicely formatted code, so output to tmp file, run stylua on it, then output formatted contents
+if success then
+	-- stylua it
+	fs.writestringtofile(sourceFilePath, code)
+	process.run(`stylua {sourceFilePath}`, { shell = true })
+	code = fs.readfiletostring(sourceFilePath)
 end
 print(code)

--- a/lua_helpers/ast_json_to_code.luau
+++ b/lua_helpers/ast_json_to_code.luau
@@ -2,6 +2,7 @@ local fs = require("@lute/fs")
 local printer = require("./temp_vendor/lute_printer") -- temp vendoring printer until my updates to support printStatement are released
 local json = require("./json")
 local process = require("@lute/process")
+local printTable = require("../lua_tests/helpers/typeAnnotationTestHelpers").printTable
 
 -- Get the source file path from command line argument
 local args = { ... }
@@ -10,10 +11,16 @@ if #args < 1 then
 	error("Usage: lute run ast_json_to_code.luau <source_file_path>")
 end
 
+-- print("Calling ast json to code:", args)
+
 local sourceFilePath = args[2]
+
+-- print(sourceFilePath)
 
 -- Read the source code from file
 local sourceCode = fs.readfiletostring(sourceFilePath)
+
+-- print(sourceCode)
 
 local astNode = json.decode(sourceCode)
 

--- a/lua_helpers/ast_json_to_code.luau
+++ b/lua_helpers/ast_json_to_code.luau
@@ -2,7 +2,6 @@ local fs = require("@lute/fs")
 local printer = require("./temp_vendor/lute_printer") -- temp vendoring printer until my updates to support printStatement are released
 local json = require("./json")
 local process = require("@lute/process")
-local printTable = require("../lua_tests/helpers/typeAnnotationTestHelpers").printTable
 
 -- Get the source file path from command line argument
 local args = { ... }
@@ -11,16 +10,10 @@ if #args < 1 then
 	error("Usage: lute run ast_json_to_code.luau <source_file_path>")
 end
 
--- print("Calling ast json to code:", args)
-
 local sourceFilePath = args[2]
-
--- print(sourceFilePath)
 
 -- Read the source code from file
 local sourceCode = fs.readfiletostring(sourceFilePath)
-
--- print(sourceCode)
 
 local astNode = json.decode(sourceCode)
 

--- a/lua_helpers/ast_json_to_code.luau
+++ b/lua_helpers/ast_json_to_code.luau
@@ -1,5 +1,5 @@
 local fs = require("@lute/fs")
-local printer = require("@std/syntax/printer")
+local printer = require("./temp_vendor/lute_printer") -- temp vendoring printer until my updates to support printStatement are released
 local json = require("./json")
 
 -- Get the source file path from command line argument
@@ -16,12 +16,11 @@ local sourceCode = fs.readfiletostring(sourceFilePath)
 
 local astNode = json.decode(sourceCode)
 
-local code
--- once printStatement functionality is added, this will work even better
--- we can just try printstatement, if fail, try printexpr and it will catch many more cases
-if astNode.tag == "block" then
-    code = printer.print(astNode)
-else
-    code = printer.printexpr(astNode)
+local code, success
+success, code = pcall(function()
+	return printer.printstatement(astNode)
+end)
+if not success then
+	code = printer.printexpr(astNode)
 end
 print(code)

--- a/lua_helpers/ast_json_to_code.luau
+++ b/lua_helpers/ast_json_to_code.luau
@@ -48,7 +48,7 @@ end
 if success then
 	-- stylua it
 	fs.writestringtofile(sourceFilePath, code)
-	process.run(`stylua {sourceFilePath}`, { shell = true })
+	process.run({'stylua', sourceFilePath})
 	code = fs.readfiletostring(sourceFilePath)
 end
 print(code)

--- a/lua_helpers/ast_json_to_code.luau
+++ b/lua_helpers/ast_json_to_code.luau
@@ -27,7 +27,7 @@ if not success then
 	end)
 end
 if not success then
-	if string.find(astNode._astType, "Token") then
+	if astNode._astType and string.find(astNode._astType, "Token") then
 		success, code = pcall(function()
 			return printer.printtoken(astNode)
 		end)

--- a/lua_helpers/ast_to_json.luau
+++ b/lua_helpers/ast_to_json.luau
@@ -8,7 +8,7 @@ local annotateWithType = require("./type_annotations").annotateWithType
 local args = { ... }
 
 if #args < 1 then
-	error("Usage: lute run ast_parser.luau <source_file_path>")
+	error("Usage: lute run ast_to_json.luau <source_file_path>")
 end
 
 local sourceFilePath = args[2]

--- a/lua_helpers/temp_vendor/lute_printer.luau
+++ b/lua_helpers/temp_vendor/lute_printer.luau
@@ -137,7 +137,7 @@ local function localVisitor(printer)
 			printer.visitToken(node.colon)
 		end
 		if node.annotation then
-			visitor.visitExpression(node.annotation, printer)
+			visitor.visitType(node.annotation, printer)
 		end
 		return false
 	end

--- a/lua_helpers/temp_vendor/lute_printer.luau
+++ b/lua_helpers/temp_vendor/lute_printer.luau
@@ -1,0 +1,151 @@
+--!strict
+local luau = require("@lute/luau")
+local visitor = require("@std/syntax/visitor")
+
+local function exhaustiveMatch(value: never): never
+	error(`Unknown value in exhaustive match: {value}`)
+end
+
+local function printTrivia(trivia: luau.Trivia): string
+	if trivia.tag == "whitespace" or trivia.tag == "comment" or trivia.tag == "blockcomment" then
+		return trivia.text
+	else
+		return exhaustiveMatch(trivia.tag)
+	end
+end
+
+local function printTriviaList(trivia: { luau.Trivia })
+	local result = ""
+	for _, trivia in trivia do
+		result ..= printTrivia(trivia)
+	end
+	return result
+end
+
+local function printToken(token: luau.Token): string
+	return printTriviaList(token.leadingTrivia) .. token.text .. printTriviaList(token.trailingTrivia)
+end
+
+local function printString(expr: luau.AstExprConstantString): string
+	local result = printTriviaList(expr.leadingTrivia)
+
+	if expr.quoteStyle == "single" then
+		result ..= `'{expr.text}'`
+	elseif expr.quoteStyle == "double" then
+		result ..= `"{expr.text}"`
+	elseif expr.quoteStyle == "block" then
+		local equals = string.rep("=", expr.blockDepth)
+		result ..= `[{equals}[{expr.text}]{equals}]`
+	elseif expr.quoteStyle == "interp" then
+		result ..= "`" .. expr.text .. "`"
+	else
+		return exhaustiveMatch(expr.quoteStyle)
+	end
+
+	result ..= printTriviaList(expr.trailingTrivia)
+	return result
+end
+
+local function printInterpolatedString(expr: luau.AstExprInterpString): string
+	local result = ""
+
+	for i = 1, #expr.strings do
+		result ..= printTriviaList(expr.strings[i].leadingTrivia)
+		if i == 1 then
+			result ..= "`"
+		else
+			result ..= "}"
+		end
+		result ..= expr.strings[i].text
+
+		if i == #expr.strings then
+			result ..= "`"
+			result ..= printTriviaList(expr.strings[i].trailingTrivia)
+		else
+			result ..= "{"
+			result ..= printTriviaList(expr.strings[i].trailingTrivia)
+			result ..= printExpr(expr.expressions[i])
+		end
+	end
+
+	return result
+end
+
+type PrintVisitor = visitor.Visitor & {
+	result: buffer,
+	cursor: number,
+}
+
+local function printVisitor()
+	local printer = visitor.createVisitor() :: PrintVisitor
+
+	printer.result = buffer.create(1024)
+	printer.cursor = 0
+
+	local function write(str: string)
+		local totalSize = printer.cursor + #str
+		local bufferSize = buffer.len(printer.result)
+
+		if totalSize >= bufferSize then
+			repeat
+				bufferSize *= 2
+			until bufferSize >= totalSize
+
+			local newBuffer = buffer.create(bufferSize)
+			buffer.copy(newBuffer, 0, printer.result)
+			printer.result = newBuffer
+		end
+
+		buffer.writestring(printer.result, printer.cursor, str)
+		printer.cursor = totalSize
+	end
+
+	printer.visitToken = function(node: luau.Token)
+		write(printToken(node))
+		return false
+	end
+
+	printer.visitString = function(node: luau.AstExprConstantString)
+		write(printString(node))
+		return false
+	end
+
+	printer.visitTypeString = function(node: luau.AstTypeSingletonString)
+		write(printString(node))
+		return false
+	end
+
+	printer.visitInterpolatedString = function(node: luau.AstExprInterpString)
+		write(printInterpolatedString(node))
+		return false
+	end
+
+	return printer
+end
+
+--- Returns a string representation of an AstExpr
+function printExpr(block: luau.AstExpr): string
+	local printer = printVisitor()
+	visitor.visitExpression(block, printer)
+	return buffer.readstring(printer.result, 0, printer.cursor)
+end
+
+--- Returns a string representation of an AstStat
+local function printStatement(statement: luau.AstStat): string
+	local printer = printVisitor()
+	visitor.visitStatement(statement, printer)
+	return buffer.readstring(printer.result, 0, printer.cursor)
+end
+
+function printFile(result: { root: luau.AstStatBlock, eof: luau.Eof }): string
+	local printer = printVisitor()
+	visitor.visitBlock(result.root, printer)
+	visitor.visitToken(result.eof, printer)
+	return buffer.readstring(printer.result, 0, printer.cursor)
+end
+
+return {
+	printexpr = printExpr,
+	printstatement = printStatement,
+	printfile = printFile,
+}

--- a/lua_helpers/temp_vendor/lute_printer.luau
+++ b/lua_helpers/temp_vendor/lute_printer.luau
@@ -15,15 +15,19 @@ local function printTrivia(trivia: luau.Trivia): string
 end
 
 local function printTriviaList(trivia: { luau.Trivia })
+	-- print("DEBUG, passed trivia to printTriviaList with val:", trivia)
 	local result = ""
 	for _, trivia in trivia do
-		result ..= printTrivia(trivia)
+		-- print("checking trivia of val:", trivia)
+		result ..= printTrivia(trivia) or ""
 	end
-	return result
+	return result or ""
 end
 
 local function printToken(token: luau.Token): string
-	return printTriviaList(token.leadingTrivia) .. token.text .. printTriviaList(token.trailingTrivia)
+	-- print("Printing Token:")
+	-- printTable(" ", token)
+	return printTriviaList(token.leadingTrivia or {}) .. token.text .. printTriviaList(token.trailingTrivia or {})
 end
 
 local function printString(expr: luau.AstExprConstantString): string
@@ -123,10 +127,42 @@ local function printVisitor()
 	return printer
 end
 
+local function localVisitor(printer)
+	local auxVisitor = visitor.createVisitor()
+	auxVisitor.visitLocal = function(node: luau.AstLocal)
+		if node.name then
+			printer.visitToken(node.name)
+		end
+		if node.colon then
+			printer.visitToken(node.colon)
+		end
+		if node.annotation then
+			visitor.visitExpression(node.annotation, printer)
+		end
+		return false
+	end
+	return auxVisitor
+end
+
 --- Returns a string representation of an AstExpr
 function printExpr(block: luau.AstExpr): string
 	local printer = printVisitor()
 	visitor.visitExpression(block, printer)
+	return buffer.readstring(printer.result, 0, printer.cursor)
+end
+
+function printLocal(node: luau.AstLocal): string
+	local printer = printVisitor()
+	local localVisitor = localVisitor(printer)
+	localVisitor.visitLocal(node)
+	return buffer.readstring(printer.result, 0, printer.cursor)
+end
+
+function printtoken(token: luau.Token): string
+	local printer = printVisitor()
+	if token then
+		printer.visitToken(token)
+	end
 	return buffer.readstring(printer.result, 0, printer.cursor)
 end
 
@@ -145,6 +181,8 @@ function printFile(result: { root: luau.AstStatBlock, eof: luau.Eof }): string
 end
 
 return {
+	printtoken = printtoken,
+	printlocal = printLocal,
 	printexpr = printExpr,
 	printstatement = printStatement,
 	printfile = printFile,

--- a/lua_tests/ast_json_to_code.spec.lua
+++ b/lua_tests/ast_json_to_code.spec.lua
@@ -19,8 +19,7 @@ end
 
 local function ast_json_to_code_test()
     local tmpFilePath = "tmpastJsonPath.lua"
-    process.run("touch tmp.txt", { shell = true })
-	process.run(`touch {tmpFilePath}`, { shell = true })
+	process.run(`echo -n > {tmpFilePath}`, { shell = true })
 	for _, code in pairs(e2eCases) do
 		fs.writestringtofile(tmpFilePath, code)
 		process.run(`stylua {tmpFilePath}`, { shell = true })

--- a/lua_tests/ast_json_to_code.spec.lua
+++ b/lua_tests/ast_json_to_code.spec.lua
@@ -19,6 +19,7 @@ end
 
 local function ast_json_to_code_test()
 	local tmpFilePath = process.cwd() .. "/lua_tests/helpers/tmpastJsonPath.lua"
+    print("tmp file path:", tmpFilePath)
 	process.run(`touch {tmpFilePath}`, { shell = true })
 	for _, code in pairs(e2eCases) do
 		fs.writestringtofile(tmpFilePath, code)

--- a/lua_tests/ast_json_to_code.spec.lua
+++ b/lua_tests/ast_json_to_code.spec.lua
@@ -1,0 +1,43 @@
+local fs = require("@lute/fs")
+local printer = require("../lua_helpers/temp_vendor/lute_printer") -- temp vendoring printer until my updates to support printStatement are released
+local json = require("../lua_helpers/json")
+local parser = require("@std/syntax/parser")
+local process = require("@lute/process")
+local testCases = require("./helpers/ast_json_to_code_test_cases")
+local printLocalCases, e2eCases = testCases.printLocalCases, testCases.e2eCases
+
+local function printer_printlocal_test()
+	for expectedOutput, testCase in printLocalCases do
+		local result = printer.printlocal(testCase)
+		assert(result == expectedOutput, "Failed printlocal on node for src code: " .. expectedOutput)
+	end
+end
+
+function trim(s)
+	return s:gsub("^%s*(.-)%s*$", "%1")
+end
+
+local function ast_json_to_code_test()
+	local tmpFilePath = process.cwd() .. "/lua_tests/helpers/tmpastJsonPath.lua"
+	process.run(`touch {tmpFilePath}`, { shell = true })
+	for _, code in pairs(e2eCases) do
+		fs.writestringtofile(tmpFilePath, code)
+		process.run(`stylua {tmpFilePath}`, { shell = true })
+		local formattedCode = trim(fs.readfiletostring(tmpFilePath))
+		local ast = parser.parse(fs.readfiletostring(tmpFilePath))
+		local astJson = json.encode(ast)
+		fs.writestringtofile(tmpFilePath, astJson)
+		local cmd = process.run({ "lute", `{process.cwd()}/lua_helpers/ast_json_to_code.luau`, tmpFilePath })
+		local formattedResult = trim(cmd.stdout)
+		process.run(`rm {tmpFilePath}`, { shell = true })
+		assert(
+			formattedResult == formattedCode,
+			"Incorrectly parsed:\n" .. formattedCode .. "\n as:\n" .. formattedResult
+		)
+	end
+end
+
+return function()
+	printer_printlocal_test()
+	ast_json_to_code_test()
+end

--- a/lua_tests/ast_json_to_code.spec.lua
+++ b/lua_tests/ast_json_to_code.spec.lua
@@ -18,7 +18,8 @@ function trim(s)
 end
 
 local function ast_json_to_code_test()
-    local tmpFilePath = "/tmp/tmpastJsonPath.lua"
+    local tmpFilePath = "tmpastJsonPath.lua"
+    process.run("touch tmp.txt", { shell = true })
 	process.run(`touch {tmpFilePath}`, { shell = true })
 	for _, code in pairs(e2eCases) do
 		fs.writestringtofile(tmpFilePath, code)

--- a/lua_tests/ast_json_to_code.spec.lua
+++ b/lua_tests/ast_json_to_code.spec.lua
@@ -18,9 +18,8 @@ function trim(s)
 end
 
 local function ast_json_to_code_test()
-	local tmpFilePath = process.cwd() .. "/lua_tests/helpers/tmpastJsonPath.lua"
-    print("tmp file path:", tmpFilePath)
-	process.run(`touch lua_tests/helpers/tmpastJsonPath.lua`, { shell = true })
+	local tmpFilePath = "./tmpastJsonPath.lua"
+	process.run(`touch {tmpFilePath}`, { shell = true })
 	for _, code in pairs(e2eCases) do
 		fs.writestringtofile(tmpFilePath, code)
 		process.run(`stylua {tmpFilePath}`, { shell = true })

--- a/lua_tests/ast_json_to_code.spec.lua
+++ b/lua_tests/ast_json_to_code.spec.lua
@@ -22,14 +22,14 @@ local function ast_json_to_code_test()
 	-- No need to create empty file, fs.writestringtofile will create it
 	for _, code in pairs(e2eCases) do
 		fs.writestringtofile(tmpFilePath, code)
-		process.run(`stylua {tmpFilePath}`, { shell = true })
+		process.run({'stylua', tmpFilePath})
 		local formattedCode = trim(fs.readfiletostring(tmpFilePath))
 		local ast = parser.parse(fs.readfiletostring(tmpFilePath))
 		local astJson = json.encode(ast)
 		fs.writestringtofile(tmpFilePath, astJson)
 		local cmd = process.run({ "lute", `{process.cwd()}/lua_helpers/ast_json_to_code.luau`, tmpFilePath })
 		local formattedResult = trim(cmd.stdout)
-		process.run(`rm {tmpFilePath}`, { shell = true })
+		process.run({'rm', tmpFilePath})
 		assert(
 			formattedResult == formattedCode,
 			"Incorrectly parsed:\n" .. formattedCode .. "\n as:\n" .. formattedResult

--- a/lua_tests/ast_json_to_code.spec.lua
+++ b/lua_tests/ast_json_to_code.spec.lua
@@ -19,7 +19,7 @@ end
 
 local function ast_json_to_code_test()
     local tmpFilePath = "tmpastJsonPath.lua"
-	process.run(`echo -n > {tmpFilePath}`, { shell = true })
+	-- No need to create empty file, fs.writestringtofile will create it
 	for _, code in pairs(e2eCases) do
 		fs.writestringtofile(tmpFilePath, code)
 		process.run(`stylua {tmpFilePath}`, { shell = true })

--- a/lua_tests/ast_json_to_code.spec.lua
+++ b/lua_tests/ast_json_to_code.spec.lua
@@ -20,7 +20,7 @@ end
 local function ast_json_to_code_test()
 	local tmpFilePath = process.cwd() .. "/lua_tests/helpers/tmpastJsonPath.lua"
     print("tmp file path:", tmpFilePath)
-	process.run(`touch {tmpFilePath}`, { shell = true })
+	process.run(`touch lua_tests/helpers/tmpastJsonPath.lua`, { shell = true })
 	for _, code in pairs(e2eCases) do
 		fs.writestringtofile(tmpFilePath, code)
 		process.run(`stylua {tmpFilePath}`, { shell = true })

--- a/lua_tests/ast_json_to_code.spec.lua
+++ b/lua_tests/ast_json_to_code.spec.lua
@@ -19,7 +19,6 @@ end
 
 local function ast_json_to_code_test()
     local tmpFilePath = "tmpastJsonPath.lua"
-	-- No need to create empty file, fs.writestringtofile will create it
 	for _, code in pairs(e2eCases) do
 		fs.writestringtofile(tmpFilePath, code)
 		process.run({'stylua', tmpFilePath})

--- a/lua_tests/ast_json_to_code.spec.lua
+++ b/lua_tests/ast_json_to_code.spec.lua
@@ -27,7 +27,7 @@ local function ast_json_to_code_test()
 		local ast = parser.parse(fs.readfiletostring(tmpFilePath))
 		local astJson = json.encode(ast)
 		fs.writestringtofile(tmpFilePath, astJson)
-		local cmd = process.run({ "lute", `{process.cwd()}/lua_helpers/ast_json_to_code.luau`, tmpFilePath })
+		local cmd = process.run({ "lute", `lua_helpers/ast_json_to_code.luau`, tmpFilePath })
 		local formattedResult = trim(cmd.stdout)
 		process.run({'rm', tmpFilePath})
 		assert(

--- a/lua_tests/ast_json_to_code.spec.lua
+++ b/lua_tests/ast_json_to_code.spec.lua
@@ -18,7 +18,7 @@ function trim(s)
 end
 
 local function ast_json_to_code_test()
-	local tmpFilePath = "./tmpastJsonPath.lua"
+	local tmpFilePath = "tmpastJsonPath.lua"
 	process.run(`touch {tmpFilePath}`, { shell = true })
 	for _, code in pairs(e2eCases) do
 		fs.writestringtofile(tmpFilePath, code)

--- a/lua_tests/ast_json_to_code.spec.lua
+++ b/lua_tests/ast_json_to_code.spec.lua
@@ -18,7 +18,7 @@ function trim(s)
 end
 
 local function ast_json_to_code_test()
-	local tmpFilePath = "tmpastJsonPath.lua"
+    local tmpFilePath = "/tmp/tmpastJsonPath.lua"
 	process.run(`touch {tmpFilePath}`, { shell = true })
 	for _, code in pairs(e2eCases) do
 		fs.writestringtofile(tmpFilePath, code)

--- a/lua_tests/helpers/ast_json_to_code_test_cases.lua
+++ b/lua_tests/helpers/ast_json_to_code_test_cases.lua
@@ -1,0 +1,90 @@
+return {
+	printLocalCases = {
+		["test"] = {
+			name = {
+				leadingTrivia = {},
+				position = {
+					line = 1,
+					column = 1,
+				},
+				text = "test",
+			},
+		},
+		["test2: number"] = {
+			name = {
+				leadingTrivia = {},
+				trailingTrivia = {},
+				position = {
+					line = 1,
+					column = 1,
+				},
+				text = "test2",
+			},
+			colon = {
+				leadingTrivia = {},
+				trailingTrivia = {
+					{
+						tag = "whitespace",
+						text = " ",
+						location = {
+							line = 1,
+							column = 1,
+						},
+					},
+				},
+				position = {
+					line = 1,
+					column = 1,
+				},
+				text = ":",
+			},
+			annotation = {
+				tag = "reference",
+				name = {
+					leadingTrivia = {},
+					trailingTrivia = {},
+					position = {
+						line = 1,
+						column = 1,
+					},
+					text = "number",
+				},
+			},
+		},
+	},
+	e2eCases = {
+		"local x = 1",
+		"x += 1",
+		"x = 2",
+		"if x == 1 then print(1) end",
+		"if x == 1 then print(1) else print(2) end",
+		"local function f(x: number) return x + 1 end",
+		"f(1)",
+		"local y = { a = 1, b = 2, ['a'] = 3 }",
+		"if y.a then print(y[a]) end",
+		"for i=1, 10 do continue end",
+		"type z = { a: number, b: string?, [string]: number }",
+		"function f(x: number) return x + 1 end",
+		"type t = z & { c: number }",
+		"type t2 = t | z",
+		"for k, v in pairs(y) do print(k, v) end",
+		"while x > 0 do x -= 1 end",
+		"repeat x += 1 until x > 10",
+		"type fn = (x: number, ...string) -> number",
+		"type optional = string?",
+		'type singleton = "literal" | true | false',
+		"local g = function(x, y) return x + y end",
+		'local h = if x > 0 then "positive" else "zero or negative"',
+		'local tbl = { [1] = "one", two = 2, "three" }',
+		"local idx = tbl[1] + tbl.two",
+		"local unary = -x + not false",
+		"local binary = x and y or false",
+		"local cast = x :: number",
+		"local group = (x + y) * 2",
+		"local vararg = ...",
+		"export type MyType = { value: number }",
+		"type Generic<T> = { data: T }",
+		"local nil_val = nil",
+		"return",
+	},
+}

--- a/lua_tests/helpers/typeAnnotationTestHelpers.lua
+++ b/lua_tests/helpers/typeAnnotationTestHelpers.lua
@@ -3,6 +3,8 @@ local visitor = require("@std/syntax/visitor")
 
 local typeAnnotationVisitor = visitor.createVisitor()
 
+local e2ecases = require("./ast_json_to_code_test_cases").e2eCases
+
 --[[
     In writing these tests, I realized we could have just used visitor to annotate types in the first place... (perhaps revisit later)
 ]]
@@ -28,7 +30,7 @@ local function verifyOutput(
 	verifier: ((node: luau.AstNode) -> boolean) | boolean
 )
 	if not node._astType then -- avoid failing on nodes that don't have a type
-		print(`Node has no type: {node}, in: {visitorFunction}`)
+		-- print(`Node has no type: {node}, in: {visitorFunction}`)
 		-- printTable(" ", node)
 		-- print("\n")
 		return
@@ -37,7 +39,7 @@ local function verifyOutput(
 		if type(verifier) == "function" then verifier(node) else verifier,
 		`Incorrectly annotated node as {node._astType} in {visitorFunction}`
 	)
-	print(`✓ Correctly annotated node as {node._astType} in {visitorFunction}`)
+	-- print(`✓ Correctly annotated node as {node._astType} in {visitorFunction}`)
 end
 
 typeAnnotationVisitor.visitToken = function(token: luau.Token)
@@ -314,41 +316,7 @@ function printTable(indent, tbl)
 	end
 end
 
-local testSrc = [[
-    local x = 1
-    x += 1
-    x = 2
-    if x == 1 then print(1) end
-    if x == 1 then print(1) else print(2) end
-    local function f(x: number) return x + 1 end
-    f(1)
-    local y = { a = 1, b = 2, ['a'] = 3 }
-    if y.a then print(y[a]) end
-    for i=1, 10 do continue end
-    type z = { a: number, b: string?, [string]: number }
-    function f(x: number) return x + 1 end
-    type t = z & { c: number }
-    type t2 = t | z
-    for k, v in pairs(y) do print(k, v) end
-    while x > 0 do x -= 1 end
-    repeat x += 1 until x > 10
-    type fn = (x: number, ...string) -> number
-    type optional = string?
-    type singleton = "literal" | true | false
-    local g = function(x, y) return x + y end
-    local h = if x > 0 then "positive" else "zero or negative"
-    local tbl = { [1] = "one", two = 2, "three" }
-    local idx = tbl[1] + tbl.two
-    local unary = -x + not false
-    local binary = x and y or false
-    local cast = x :: number
-    local group = (x + y) * 2
-    local vararg = ...
-    export type MyType = { value: number }
-    type Generic<T> = { data: T }
-    local nil_val = nil
-    return
-]]
+local testSrc = table.concat(e2ecases, "\n")
 
 local ambiguousTagTestCases = {
 	-- {nodeTable, expectedType, description}

--- a/lua_tests/helpers/typeAnnotationTestHelpers.lua
+++ b/lua_tests/helpers/typeAnnotationTestHelpers.lua
@@ -29,8 +29,8 @@ local function verifyOutput(
 )
 	if not node._astType then -- avoid failing on nodes that don't have a type
 		print(`Node has no type: {node}, in: {visitorFunction}`)
-        -- printTable(" ", node)
-        -- print("\n")
+		-- printTable(" ", node)
+		-- print("\n")
 		return
 	end
 	assert(
@@ -351,47 +351,47 @@ local testSrc = [[
 ]]
 
 local ambiguousTagTestCases = {
-    -- {nodeTable, expectedType, description}
-    {{ tag = "conditional", endKeyword = {} }, "AstStatIf", "if statement"},
-    {{ tag = "conditional" }, "AstExprIfElse", "if expression"},
-    {{ tag = "function", returnArrow = {} }, "AstTypeFunction", "type function"},
-    {{ tag = "function", name = {} }, "AstStatFunction", "function statement"},
-    {{ tag = "function" }, "AstExprAnonymousFunction", "anonymous function"},
-    {{ tag = "group", expression = {} }, "AstExprGroup", "expression group"},
-    {{ tag = "group", type = {} }, "AstTypeGroup", "type group"},
-    {{ tag = "local", token = {}, upvalue = false }, "AstExprLocal", "local expression"},
-    {{ tag = "local", localKeyword = {}, variables = {} }, "AstStatLocal", "local statement"},
-    {{ tag = "generic", ellipsis = {} }, "AstTypePackGeneric", "generic type pack"},
-    {{ tag = "generic" }, "AstGenericType", "generic type"},
+	-- {nodeTable, expectedType, description}
+	{ { tag = "conditional", endKeyword = {} }, "AstStatIf", "if statement" },
+	{ { tag = "conditional" }, "AstExprIfElse", "if expression" },
+	{ { tag = "function", returnArrow = {} }, "AstTypeFunction", "type function" },
+	{ { tag = "function", name = {} }, "AstStatFunction", "function statement" },
+	{ { tag = "function" }, "AstExprAnonymousFunction", "anonymous function" },
+	{ { tag = "group", expression = {} }, "AstExprGroup", "expression group" },
+	{ { tag = "group", type = {} }, "AstTypeGroup", "type group" },
+	{ { tag = "local", token = {}, upvalue = false }, "AstExprLocal", "local expression" },
+	{ { tag = "local", localKeyword = {}, variables = {} }, "AstStatLocal", "local statement" },
+	{ { tag = "generic", ellipsis = {} }, "AstTypePackGeneric", "generic type pack" },
+	{ { tag = "generic" }, "AstGenericType", "generic type" },
 }
 
 local ambiguousKeyTestCases = {
-    -- {key, node, parent, expectedType, description}
-    {"body", {statements={}, openParens={}}, {}, "AstFunctionBody", "function body"},
-    {"body", {statements={}}, {tag="if"}, "AstStatBlock", "if body"},
-    {"operand", {tag="call"}, {operator={}}, "AstExpr", "unary operand"},
-    {"self", {}, {}, "AstLocal", "self parameter"},
-    {"self", {}, {tag={}}, "boolean", "no self parameter"},
-    {"condition", {tag="binary"}, {}, "AstExpr", "condition expression"},
-    {"expression", {tag="call"}, {}, "AstExpr", "expression"},
-    {"func", {tag="function"}, {}, "AstExpr", "function expression"},
-    {"key", {}, {kind="record"}, "Token", "record key"},
-    {"key", {}, {kind="indexer"}, "AstType", "indexer key"},
-    {"key", {}, {kind="general"}, "AstExpr", "general key"},
-    -- we should focus on the most ambiguous case
-    {"value", {}, {colon={}}, "AstType", "type value"},
-    {"value", {}, {kind="general"}, "AstExpr", "expression value"},
-    {"value", {}, {tag="boolean"}, "boolean", "boolean value"},
-    {"value", {}, {tag="number"}, "number", "number value"},
-    {"name", {text="x"}, {}, "Token", "token name"},
-    {"name", {name={}}, {}, "AstLocal", "local name"},
-    {"name", {}, {}, "AstExpr", "expr name"},
+	-- {key, node, parent, expectedType, description}
+	{ "body", { statements = {}, openParens = {} }, {}, "AstFunctionBody", "function body" },
+	{ "body", { statements = {} }, { tag = "if" }, "AstStatBlock", "if body" },
+	{ "operand", { tag = "call" }, { operator = {} }, "AstExpr", "unary operand" },
+	{ "self", {}, {}, "AstLocal", "self parameter" },
+	{ "self", {}, { tag = {} }, "boolean", "no self parameter" },
+	{ "condition", { tag = "binary" }, {}, "AstExpr", "condition expression" },
+	{ "expression", { tag = "call" }, {}, "AstExpr", "expression" },
+	{ "func", { tag = "function" }, {}, "AstExpr", "function expression" },
+	{ "key", {}, { kind = "record" }, "Token", "record key" },
+	{ "key", {}, { kind = "indexer" }, "AstType", "indexer key" },
+	{ "key", {}, { kind = "general" }, "AstExpr", "general key" },
+	-- we should focus on the most ambiguous case
+	{ "value", {}, { colon = {} }, "AstType", "type value" },
+	{ "value", {}, { kind = "general" }, "AstExpr", "expression value" },
+	{ "value", {}, { tag = "boolean" }, "boolean", "boolean value" },
+	{ "value", {}, { tag = "number" }, "number", "number value" },
+	{ "name", { text = "x" }, {}, "Token", "token name" },
+	{ "name", { name = {} }, {}, "AstLocal", "local name" },
+	{ "name", {}, {}, "AstExpr", "expr name" },
 }
 
 return {
 	typeAnnotationVisitor = typeAnnotationVisitor,
 	testSrc = testSrc,
 	printTable = printTable,
-    ambiguousTagTestCases = ambiguousTagTestCases,
-    ambiguousKeyTestCases = ambiguousKeyTestCases,
+	ambiguousTagTestCases = ambiguousTagTestCases,
+	ambiguousKeyTestCases = ambiguousKeyTestCases,
 }

--- a/lua_tests/runner.luau
+++ b/lua_tests/runner.luau
@@ -13,6 +13,7 @@ for m, file in fs.listdir(test_path) do
 	local filePath = "./" .. trim_luau_ext(file.name)
 	local test = require(filePath)
 	assert(typeof(test) == "function", "Test suite is not a function")
+	print(`\n======= Running {file.name} =======\n`)
 	test()
 	print(`\n======= ✓ {file.name} passed =======\n`)
 end

--- a/package.json
+++ b/package.json
@@ -77,8 +77,8 @@
     "watch": "tsc -watch -p ./",
     "dev": "npm run build:frontend && npm run watch",
     "package": "vsce package",
-    "test:compile": "jest && npm run compile",
-    "test": "jest",
+    "test:compile": "cd frontend && npm test && npm run compile",
+    "test": "cd frontend && npm test",
     "process-changelog": "npx ts-node ci_scripts/read_changelog.ts"
   },
   "devDependencies": {

--- a/src/astParser.ts
+++ b/src/astParser.ts
@@ -107,8 +107,6 @@ export class ASTParserAndPrinter {
           cwd: workspaceRoot, // Set working directory to workspace root
         });
 
-        console.log("ASTPrinter output:", stdout);
-
         if (stderr && !stdout) {
           throw new Error(`Lute error: ${stderr}`);
         }

--- a/src/astParser.ts
+++ b/src/astParser.ts
@@ -106,8 +106,6 @@ export class ASTParserAndPrinter {
           cwd: workspaceRoot, // Set working directory to workspace root
         });
 
-        console.log("ASTPrinter:", stdout, stderr)
-
         if (stderr && !stdout) {
           throw new Error(`Lute error: ${stderr}`);
         }

--- a/src/astParser.ts
+++ b/src/astParser.ts
@@ -85,7 +85,6 @@ export class ASTParserAndPrinter {
 
       try {
         // Use the permanent AST parser script from extension directory
-        console.log("ASTPrinter: printing selected ast node:", nodeJson);
         const astPrinterPath = path.join(
           this.extensionPath,
           "lua_helpers",
@@ -106,6 +105,8 @@ export class ASTParserAndPrinter {
           maxBuffer: 1024 * 1024, // 1MB buffer
           cwd: workspaceRoot, // Set working directory to workspace root
         });
+
+        console.log("ASTPrinter:", stdout, stderr)
 
         if (stderr && !stdout) {
           throw new Error(`Lute error: ${stderr}`);
@@ -137,7 +138,10 @@ export class ASTParserAndPrinter {
     return supportedLanguages.includes(languageId.toLowerCase());
   }
 
-  private async createTempFile(code: string, fileExt: string = "luau"): Promise<string> {
+  private async createTempFile(
+    code: string,
+    fileExt: string = "luau"
+  ): Promise<string> {
     const tempDir = os.tmpdir();
     const tempFileName = `to_parse_${Date.now()}.${fileExt}`;
     const tempFilePath = path.join(tempDir, tempFileName);

--- a/src/astParser.ts
+++ b/src/astParser.ts
@@ -167,7 +167,9 @@ export class ASTParserAndPrinter {
 
       try {
         // Use the permanent AST parser script from extension directory
-        console.log("ASTParser: parsing selected code:", srcCode);
+
+        // console.log("ASTParser: parsing selected code:", srcCode);
+        
         const astParserPath = path.join(
           this.extensionPath,
           "lua_helpers",


### PR DESCRIPTION
## Problem

We have no path information in current display so naively display node path as title.

It would also be super cool if we could see corresponding code snippets when hovering printable nodes.

## Solution

Add path prop to `TreeNode`; display on hover for unprintable nodes.

For printable nodes, display translated code on hover. Process works as follows:
- add `useCodeTooltip` hook that is called at the container level (`App.tsx`) and maintains a cache state of AST node -> translated code mapping. Exposes the cache and functions to request node translation and handle response from luau side
	- cache and helper functions are passed to `TreeNode` via context
- On hover, node requests a translation (calls `requestCodeTooltip`)
- we send JSON encoding of the node to Luau side where we
	- create temp file with the JSON content
	- call `ast_json_to_code.luau` with the temp file path; it:
		- decodes JSON into table (JSON becomes a visitable/printable AST node)
		- outputs corresponding src code for AST node (if it is printable, otherwise just errs)
	- grab stdout (or error) from `ast_json_to_code` and send message back to webview with corresponding status and result
- at this point, we handle the response msg by updating the code tooltip cache:
	- if success, we set the value for returned nodeID to returned src code string
	- if err, we remove the returned nodeID from the cache

## To-Do
~- add specific styling for displayed code
	-  fix formatting so it prints clean (maybe stylua it)~
~- add tests for syntaxHighlighting~
~- pass codeTooltips via context? rather than prop drilling? What's more performant...~
- clean up redudancies / LLM slop
~- add tests for `ast_json_to_code`~
- change styling of codeTooltip slightly