### PR TITLE
#feat Smarter auto-collapse based off node type

### DIFF
--- a/.changes/31-feat.md
+++ b/.changes/31-feat.md
@@ -1,0 +1,1 @@
+Smarter auto-collapse based off node type

--- a/frontend/src/TreeNode.tsx
+++ b/frontend/src/TreeNode.tsx
@@ -84,7 +84,6 @@ export const TreeNode: React.FC<TreeNodeProps> = ({
         return "diff-updated";
       case "contains-changes":
       case "contains-nested-changes":
-      case "nested-add":
         return expanded ? "" : "diff-contains-changes";
       default:
         return "";
@@ -165,7 +164,6 @@ export const TreeNode: React.FC<TreeNodeProps> = ({
         return <span className="diff-indicator diff-updated-indicator">~</span>;
       case "contains-changes":
       case "contains-nested-changes":
-      case "nested-add":
         return expanded ? (
           ""
         ) : (
@@ -416,7 +414,7 @@ const TreeNodeContainer: React.FC<TreeNodeContainerProps> = (props) => {
   }, [type]);
 
   const autoCollapse = props.isDiffMode
-    ? props.diffStatus === "unchanged"
+    ? props.diffStatus === "unchanged" || shouldAutoCollapse(type, typeDefinition)
     : shouldAutoCollapse(type, typeDefinition);
 
   const [expanded, setExpanded] = React.useState(!autoCollapse);

--- a/frontend/src/TreeNode.tsx
+++ b/frontend/src/TreeNode.tsx
@@ -7,6 +7,7 @@ import {
   getType,
   unpackArrayType,
 } from "./utils/astTypeHelpers";
+import { ASTTypeDefinition } from "./utils/astTypeDefinitions";
 
 interface TreeNodeProps {
   nodeKey: string;
@@ -14,6 +15,10 @@ interface TreeNodeProps {
   level: number;
   expanded: boolean;
   onToggle: () => void;
+  type: string;
+  typeDefinition: ASTTypeDefinition | undefined;
+  kind: string;
+  arrayType: boolean;
   searchTerm?: string;
   parentInferredType?: string | string[];
   isDiffMode?: boolean;
@@ -36,6 +41,10 @@ export const TreeNode: React.FC<TreeNodeProps> = ({
   level,
   expanded,
   onToggle,
+  type,
+  typeDefinition,
+  kind,
+  arrayType,
   searchTerm = "",
   isDiffMode = false,
   parentInferredType,
@@ -47,18 +56,6 @@ export const TreeNode: React.FC<TreeNodeProps> = ({
   // Always reserve space for diff indicator to maintain consistent indentation
   const baseIndent = "  ".repeat(level);
   const indent = baseIndent;
-
-  // get all this metadata at tree node level; pass to TypeTooltip
-  const [type, kind] = React.useMemo(() => {
-    return getTypeString(value, nodeKey, parentInferredType);
-  }, [value, nodeKey, parentInferredType]);
-
-  const [typeDefinition, arrayType] = React.useMemo(() => {
-    if (type) {
-      return getType(type);
-    }
-    return [undefined, false];
-  }, [type]);
 
   const renderTypeAnnotations = React.useCallback(() => {
     if (type) {
@@ -406,9 +403,21 @@ interface TreeNodeContainerProps {
 }
 
 const TreeNodeContainer: React.FC<TreeNodeContainerProps> = (props) => {
+  // get all this metadata at tree node level; pass to TypeTooltip
+  const [type, kind] = React.useMemo(() => {
+    return getTypeString(props.value, props.nodeKey, props.parentInferredType);
+  }, [props.value, props.nodeKey, props.parentInferredType]);
+
+  const [typeDefinition, arrayType] = React.useMemo(() => {
+    if (type) {
+      return getType(type);
+    }
+    return [undefined, false];
+  }, [type]);
+
   const autoCollapse = props.isDiffMode
     ? props.diffStatus === "unchanged"
-    : shouldAutoCollapse(props.nodeKey);
+    : shouldAutoCollapse(type, typeDefinition);
 
   const [expanded, setExpanded] = React.useState(!autoCollapse);
 
@@ -421,7 +430,17 @@ const TreeNodeContainer: React.FC<TreeNodeContainerProps> = (props) => {
     return null;
   }
 
-  return <TreeNode {...props} expanded={expanded} onToggle={handleToggle} />;
+  return (
+    <TreeNode
+      {...props}
+      expanded={expanded}
+      onToggle={handleToggle}
+      type={type}
+      typeDefinition={typeDefinition}
+      kind={kind}
+      arrayType={arrayType}
+    />
+  );
 };
 
 export default TreeNodeContainer;

--- a/frontend/src/nodeEmphasisHelpers.ts
+++ b/frontend/src/nodeEmphasisHelpers.ts
@@ -7,7 +7,8 @@ export const autoCollapseTypes = [
   "SingleLineComment",
   "MultiLineComment",
   "Trivia",
-  "Location"
+  "Location",
+  "Position"
 ];
 
 // auto-collapse if type is:

--- a/frontend/src/nodeEmphasisHelpers.ts
+++ b/frontend/src/nodeEmphasisHelpers.ts
@@ -1,94 +1,47 @@
-// Metadata - debugging/structural info, least visually important
-export const metadata = [
-  // Location and position information
-  "leadingTrivia",
-  "trailingTrivia",
-  "location",
-  "position",
-  "argLocation",
-  "indexLocation",
+import { ASTTypeDefinition } from "./utils/astTypeDefinitions";
+import { unpackArrayType } from "./utils/astTypeHelpers";
 
-  // Structural metadata
-  "upvalue",
-  "self",
-  "blockDepth",
-  "quoteStyle",
+export const autoCollapseTypes = [
+  "Token",
+  "Whitespace",
+  "SingleLineComment",
+  "MultiLineComment",
+  "Trivia",
+  "Location"
 ];
 
-// Secondary - structural keywords and important syntax, medium importance
-export const secondary = [
-  // Language keywords
-  "functionKeyword",
-  "localKeyword",
-  "ifKeyword",
-  "thenKeyword",
-  "elseKeyword",
-  "elseifKeyword",
-  "endKeyword",
-  "whileKeyword",
-  "doKeyword",
-  "forKeyword",
-  "inKeyword",
-  "repeatKeyword",
-  "untilKeyword",
-  "returnKeyword",
-  "breakKeyword",
-  "continueKeyword",
-  "export",
-  "typeToken",
+// auto-collapse if type is:
+//   one of the autoCollapseTypes
+//   an array of autoCollapseTypes
+//   a union of autoCollapseTypes
+//   an extension of autoCollapseTypes
+export const shouldAutoCollapse = (
+  type: string | string[],
+  typeDefinition?: ASTTypeDefinition
+): boolean => {
+  if (type) {
+    if (typeof type == "string") {
+      if (autoCollapseTypes.includes(type)) return true;
 
-  // Block delimiters (more important than pure syntax)
-  "openBrace",
-  "closeBrace",
-  "openParens",
-  "closeParens",
-  "openParen",
-  "closeParen",
+      if (autoCollapseTypes.includes(unpackArrayType(type))) return true;
+    }
 
-  // Generic/type delimiters
-  "openGenerics",
-  "closeGenerics",
+    if (typeDefinition && typeDefinition.unionMembers) {
+      typeDefinition.unionMembers.forEach((member) => {
+        if (shouldAutoCollapse(member)) {
+          return true;
+        }
+      });
+    }
 
-  // Names and tokens (identifiers)
-  "name",
-  "token",
-];
+    if (
+      typeDefinition &&
+      typeDefinition.baseType &&
+      autoCollapseTypes.includes(typeDefinition.baseType)
+    ) {
+      return true;
+    }
+  }
 
-// Syntax - pure punctuation, operators, separators, least structurally important
-export const syntax = [
-  // Brackets and indexing
-  "openBrackets",
-  "closeBrackets",
-  "openBracket",
-  "closeBracket",
-
-  // Operators and assignment
-  "equals",
-  "operator",
-  "accessor",
-  "colon",
-
-  // Separators and punctuation
-  "comma",
-  "semicolon",
-  "ellipsis",
-];
-
-// Helper functions for categorizing nodes
-export const getNodeImportance = (
-  nodeKey: string
-): "metadata" | "secondary" | "syntax" | "primary" => {
-  if (metadata.includes(nodeKey)) return "metadata";
-  if (secondary.includes(nodeKey)) return "secondary";
-  if (syntax.includes(nodeKey)) return "syntax";
-  return "primary";
-};
-
-export const getNodeImportanceClass = (nodeKey: string): string => {
-  const importance = getNodeImportance(nodeKey);
-  return `node-${importance}`;
-};
-
-export const shouldAutoCollapse = (nodeKey: string): boolean => {
-  return getNodeImportance(nodeKey) !== "primary";
+  return false;
 };

--- a/frontend/src/nodeEmphasisHelpers.ts
+++ b/frontend/src/nodeEmphasisHelpers.ts
@@ -6,9 +6,8 @@ export const autoCollapseTypes = [
   "Whitespace",
   "SingleLineComment",
   "MultiLineComment",
-  "Trivia",
   "Location",
-  "Position"
+  "Position",
 ];
 
 // auto-collapse if type is:
@@ -25,23 +24,34 @@ export const shouldAutoCollapse = (
       if (autoCollapseTypes.includes(type)) return true;
 
       if (autoCollapseTypes.includes(unpackArrayType(type))) return true;
-    }
-
-    if (typeDefinition && typeDefinition.unionMembers) {
-      typeDefinition.unionMembers.forEach((member) => {
-        if (shouldAutoCollapse(member)) {
+    } else {
+      for (const t of type) {
+        if (shouldAutoCollapse(t)) {
+          return true;
+        }
+      }
+      autoCollapseTypes.forEach((type) => {
+        if (shouldAutoCollapse(type)) {
           return true;
         }
       });
     }
+  }
 
-    if (
-      typeDefinition &&
-      typeDefinition.baseType &&
-      autoCollapseTypes.includes(typeDefinition.baseType)
-    ) {
-      return true;
+  if (typeDefinition && typeDefinition.unionMembers) {
+    for (const member of typeDefinition.unionMembers) {
+      if (shouldAutoCollapse(member)) {
+        return true;
+      }
     }
+  }
+
+  if (
+    typeDefinition &&
+    typeDefinition.baseType &&
+    autoCollapseTypes.includes(typeDefinition.baseType)
+  ) {
+    return true;
   }
 
   return false;

--- a/frontend/src/tests/nodeEmphasisHelpers.test.ts
+++ b/frontend/src/tests/nodeEmphasisHelpers.test.ts
@@ -1,0 +1,42 @@
+import { shouldAutoCollapse, autoCollapseTypes } from "../nodeEmphasisHelpers";
+import { astTypeDefinitions } from "../utils/astTypeDefinitions";
+
+describe("shouldAutoCollapse", () => {
+  test("should return true for standard auto-collapse types", () => {
+    autoCollapseTypes.forEach((type) => {
+      expect(shouldAutoCollapse(type)).toBe(true);
+    });
+  });
+
+  test("should return true for tables of auto-collapse types", () => {
+    const tableTypes = autoCollapseTypes.map((type) => {
+      return `{ ${type} }`;
+    });
+
+    tableTypes.forEach((type) => {
+      expect(shouldAutoCollapse(type)).toBe(true);
+    });
+  });
+
+  test("should return true for unions of auto-collapsable types", () => {
+    const triviaTypeDefinition = astTypeDefinitions["Trivia"]; // example of type that is union of types that should auto-collapse
+    const falseUnionType = astTypeDefinitions["AstExpr"]
+    expect(shouldAutoCollapse("", triviaTypeDefinition)).toBe(true);
+    expect(shouldAutoCollapse("", falseUnionType)).toBe(false);
+  });
+
+  test("should return true for extensions of auto-collapsable types", () => {
+    const extendedTypes = Object.entries(astTypeDefinitions)
+      .filter(([_, def]) => def.baseType)
+      .map(([type]) => type);
+
+    extendedTypes.forEach((type) => {
+      const typeDef = astTypeDefinitions[type];
+      if (autoCollapseTypes.includes(typeDef.baseType as string)) {
+        expect(shouldAutoCollapse(type, typeDef)).toBe(true);
+      } else {
+        expect(shouldAutoCollapse(type, typeDef)).toBe(false);
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Problem

Right now we auto-collapse based off node key. This is dumb and very manual, it's hard to catch every case of irrelevant node in elegant way.

## Solution

Collapse based off of type instead! Tokens, Trivia, Location, and position are all mostly irrelevant and encompass many node types together. 
