### PR TITLE
#chore Fix Release Workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,6 +103,8 @@ jobs:
         steps:
             - name: Checkout code
               uses: actions/checkout@v3
+              with:
+                fetch-depth: 0
 
             - name: Install dependencies
               run: |


### PR DESCRIPTION
## Problem

Release get changelog diff failed bc there was shallow commit history. (so `HEAD~1` was invalid)

## Solution

Ensure we have full commit history when checking out repo
