### PR TITLE
#bug Fix diffing so removed nodes are included in annotated AST

### DIFF
--- a/.changes/36-bug.md
+++ b/.changes/36-bug.md
@@ -1,0 +1,1 @@
+Fix diffing so removed nodes are included in annotated AST

--- a/.changes/36-bug.md
+++ b/.changes/36-bug.md
@@ -1,1 +1,1 @@
-Fix diffing so removed nodes are included in annotated AST
+Fix diffing module so removed nodes are included in diff-annotated output. Consolidate `diffUtils` redundancies and repeated logic into functions.

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -188,7 +188,6 @@
   background-color: rgba(248, 81, 73, 0.2);
   border-left: 3px solid #dc3545;
   padding-left: 4px;
-  text-decoration: line-through;
 }
 
 .diff-updated {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -179,28 +179,28 @@
 
 /* Diff visualization styles */
 .diff-added {
-  background-color: rgba(46, 160, 67, 0.2);
-  border-left: 3px solid #28a745;
+  background-color: color-mix(in srgb, var(--vscode-gitDecoration-addedResourceForeground, #28a745) 20%, transparent);
+  border-left: 3px solid var(--vscode-gitDecoration-addedResourceForeground, #28a745);
   padding-left: 4px;
 }
 
 .diff-removed {
-  background-color: rgba(248, 81, 73, 0.2);
-  border-left: 3px solid #dc3545;
+  background-color: color-mix(in srgb, var(--vscode-gitDecoration-deletedResourceForeground, #dc3545) 20%, transparent);
+  border-left: 3px solid var(--vscode-gitDecoration-deletedResourceForeground, #dc3545);
   padding-left: 4px;
 }
 
 .diff-updated {
-  background-color: rgba(52, 144, 220, 0.2);
-  border-left: 3px solid #3490dc;
+  background-color: color-mix(in srgb, var(--vscode-gitDecoration-modifiedResourceForeground, #3490dc) 20%, transparent);
+  border-left: 3px solid var(--vscode-gitDecoration-modifiedResourceForeground, #3490dc);
   padding-left: 4px;
 }
 
 /* Styling for parent nodes that contain changes */
 .diff-contains-changes {
-  border-left: 3px solid #3490dc;
+  border-left: 3px solid var(--vscode-gitDecoration-modifiedResourceForeground, #3490dc);
   padding-left: 4px;
-  background-color: rgba(52, 144, 220, 0.05);
+  background-color: color-mix(in srgb, var(--vscode-gitDecoration-modifiedResourceForeground, #3490dc) 5%, transparent);
 }
 
 .diff-indicator {
@@ -212,30 +212,30 @@
 }
 
 .diff-added-indicator {
-  color: #28a745;
+  color: var(--vscode-gitDecoration-addedResourceForeground, #28a745);
 }
 
 .diff-removed-indicator {
-  color: #dc3545;
+  color: var(--vscode-gitDecoration-deletedResourceForeground, #dc3545);
 }
 
 .diff-updated-indicator {
-  color: #3490dc;
+  color: var(--vscode-gitDecoration-modifiedResourceForeground, #3490dc);
 }
 
 .diff-before {
   text-decoration: line-through;
-  color: #dc3545;
+  color: var(--vscode-gitDecoration-deletedResourceForeground, #dc3545);
 }
 
 .diff-arrow {
-  color: var(--vscode-gitDecoration-modifiedResourceForeground);
+  color: var(--vscode-gitDecoration-modifiedResourceForeground, #3490dc);
   font-weight: bold;
   margin: 0 4px;
 }
 
 .diff-after {
-  color: var(--vscode-gitDecoration-addedResourceForeground);
+  color: var(--vscode-gitDecoration-addedResourceForeground, #28a745);
   font-weight: bold;
 }
 

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -196,10 +196,11 @@
   padding-left: 4px;
 }
 
+/* Styling for parent nodes that contain changes */
 .diff-contains-changes {
-  border-left: 2px solid #3490dc;
-  padding-left: 2px;
-  /* Subtle styling for parent nodes that contain changes */
+  border-left: 3px solid #3490dc;
+  padding-left: 4px;
+  background-color: rgba(52, 144, 220, 0.05);
 }
 
 .diff-indicator {
@@ -237,15 +238,6 @@
   color: var(--vscode-gitDecoration-addedResourceForeground);
   font-weight: bold;
 }
-
-/* Styling for parent nodes that contain changes */
-.diff-contains-changes {
-  border-left: 2px solid #3490dc;
-  padding-left: 2px;
-  background-color: rgba(52, 144, 220, 0.05);
-}
-
- 
 
 .stats {
   font-size: 11px;

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -181,25 +181,21 @@
 .diff-added {
   background-color: color-mix(in srgb, var(--vscode-gitDecoration-addedResourceForeground, #28a745) 20%, transparent);
   border-left: 3px solid var(--vscode-gitDecoration-addedResourceForeground, #28a745);
-  padding-left: 4px;
 }
 
 .diff-removed {
   background-color: color-mix(in srgb, var(--vscode-gitDecoration-deletedResourceForeground, #dc3545) 20%, transparent);
   border-left: 3px solid var(--vscode-gitDecoration-deletedResourceForeground, #dc3545);
-  padding-left: 4px;
 }
 
 .diff-updated {
   background-color: color-mix(in srgb, var(--vscode-gitDecoration-modifiedResourceForeground, #3490dc) 20%, transparent);
   border-left: 3px solid var(--vscode-gitDecoration-modifiedResourceForeground, #3490dc);
-  padding-left: 4px;
 }
 
 /* Styling for parent nodes that contain changes */
 .diff-contains-changes {
   border-left: 3px solid var(--vscode-gitDecoration-modifiedResourceForeground, #3490dc);
-  padding-left: 4px;
   background-color: color-mix(in srgb, var(--vscode-gitDecoration-modifiedResourceForeground, #3490dc) 5%, transparent);
 }
 

--- a/frontend/src/TreeNode.tsx
+++ b/frontend/src/TreeNode.tsx
@@ -113,7 +113,7 @@ export const TreeNode: React.FC<TreeNodeProps> = ({
               beforeValue: child.beforeValue,
               afterValue: child.afterValue,
             }
-          : childChange // handles cases where child is primitive value
+          : childChange // handles cases where child is primitive value (since diffStatus wont exist on the child node itself)
           ? {
               isDiffMode,
               diffStatus:
@@ -174,7 +174,7 @@ export const TreeNode: React.FC<TreeNodeProps> = ({
       case "contains-changes":
       case "contains-nested-changes":
         return expanded ? (
-          ""
+          <span className="diff-indicator"></span>
         ) : (
           <span className="diff-indicator diff-updated-indicator">○</span>
         );
@@ -196,13 +196,8 @@ export const TreeNode: React.FC<TreeNodeProps> = ({
 
       switch (diffStatus) {
         case "added":
-          return highlightText(`${nodeKey}: ${displayValue}`);
         case "removed":
-          const beforeDisplayValue =
-            typeof beforeValue === "string"
-              ? `"${beforeValue}"`
-              : String(beforeValue);
-          return highlightText(`${nodeKey}: ${beforeDisplayValue}`);
+          return highlightText(`${nodeKey}: ${displayValue}`);
         case "updated":
           const beforeDisplay =
             typeof beforeValue === "string"

--- a/frontend/src/diffUtils.ts
+++ b/frontend/src/diffUtils.ts
@@ -128,7 +128,7 @@ export function annotateDiffTreeRecursive(
     );
 
     if (directChange) {
-      // This node itself has changed - annotate it if possible
+      // This node itself has changed - annotate it if possible (only occurs for primitive values, objects can only contain child/nested changes)
       if (typeof node === "object" && node !== null) {
         switch (directChange.type) {
           case "ADD":
@@ -222,7 +222,6 @@ export function annotateDiffTreeRecursive(
         // Handle arrays - use dot notation to match json-diff-ts format
         node[key].forEach((item: any, index: number) => {
           if (item && typeof item === "object") {
-            // console.log("Handling array item:", item, index);
             const arrayPath = `${childPath}.${index}`;
             annotateDiffTreeRecursive(
               item,

--- a/frontend/src/diffUtils.ts
+++ b/frontend/src/diffUtils.ts
@@ -62,7 +62,7 @@ export function getDirectChildChanges(
       const pathPrefix = nodePath ? `${nodePath}.` : "";
       if (!path.startsWith(pathPrefix)) return false;
       const remainingPath =
-        nodePath == "" ? path : path.substring(nodePath.length + 1);
+        nodePath === "" ? path : path.substring(nodePath.length + 1);
       const isDirectChild = !remainingPath.includes("."); // No further dots = direct child
       nestedDescendantChanges = nestedDescendantChanges || !isDirectChild;
       return isDirectChild;
@@ -84,8 +84,8 @@ export function setChildChanges(
   (node as any).childChanges = directChildChanges.reduce((acc, changePath) => {
     const change = changeMap.get(changePath);
     const childKey =
-      nodePath == "" ? changePath : changePath.substring(nodePath.length + 1);
-    if (change?.type == "REMOVE") {
+      nodePath === "" ? changePath : changePath.substring(nodePath.length + 1);
+    if (change?.type === "REMOVE") {
       console.log("Injecting removal:", change);
       // inject removed child to node
       node[childKey] = change.value;

--- a/frontend/src/nodeEmphasisHelpers.ts
+++ b/frontend/src/nodeEmphasisHelpers.ts
@@ -2,7 +2,7 @@ import { ASTTypeDefinition } from "./utils/astTypeDefinitions";
 import { unpackArrayType } from "./utils/astTypeHelpers";
 
 export const autoCollapseTypes = [
-  "Token",
+  // "Token",
   "Whitespace",
   "SingleLineComment",
   "MultiLineComment",

--- a/frontend/src/tests/diffUtils.test.ts
+++ b/frontend/src/tests/diffUtils.test.ts
@@ -27,9 +27,7 @@ var obj1: astNode = {
   },
   unnestedText: "b",
   array: {
-    items: {
-      0: "a",
-    },
+    items: ["a"],
   },
   removedText: "bye",
 };
@@ -43,21 +41,14 @@ var obj2: astNode = {
   },
   unnestedText: "a",
   array: {
-    items: {},
+    items: [],
   },
   add: {
     nestedAdd: {
-      doubleNested: {}
+      doubleNested: {},
     },
   },
 };
-// const expectedChildChanges = new Map<string, any[]>(); // map path to [# of expected childChanges, childChange keys]
-// expectedChildChanges.set("", [2, "unnestedText", "removedText"]);
-// expectedChildChanges.set("value", [2, "value.text", "value.newText"]);
-// expectedChildChanges.set("value.doubleNest", [1, "value.doubleNest.a"]);
-// expectedChildChanges.set("array", [1, "array.0"]);
-// expectedChildChanges.set("unnestedText", [0]);
-// expectedChildChanges.set("removedText", [0]);
 
 const changeMap = getChangeMap(obj1, obj2);
 
@@ -83,16 +74,6 @@ describe("diffUtils test", () => {
   // we can test by manually constructing objects (ob1 -> obj2), getting diff, building changeMap. Then check that changeMap contains the paths we manually change in obj construction
   // essentially want to ensure that paths are correct,
   test("buildChangeMap", () => {
-    // expectedChildChanges.forEach((nodeChildChanges, nodePath) => {
-    //   if (nodeChildChanges[0] > 0) {
-    //     expect(changeMap.get(nodePath)).toBeUndefined();
-    //     nodeChildChanges.forEach((changePath) => {
-    //       if (typeof changePath === "string") {
-    //         expect(changeMap.get(changePath)).toBeDefined();
-    //       }
-    //     });
-    //   }
-    // });
     expect(changeMap.get("value.text")).toBeDefined();
     expect(changeMap.get("value.text")?.type).toEqual("UPDATE");
     expect(changeMap.get("value.doubleNest.a")).toBeDefined();
@@ -189,8 +170,35 @@ describe("diffUtils test", () => {
     expect(diffTree.value.diffStatus).toEqual("contains-changes");
     expect(diffTree.value.doubleNest.diffStatus).toEqual("contains-changes");
     expect(diffTree.array.diffStatus).toEqual("contains-nested-changes");
+    expect(diffTree.array.items.diffStatus).toEqual("contains-changes");
     expect(diffTree.add.diffStatus).toEqual("added");
     expect(diffTree.add.nestedAdd.diffStatus).toEqual("nested-add");
-    expect(diffTree.add.nestedAdd.doubleNested.diffStatus).toEqual("nested-add");
+    expect(diffTree.add.nestedAdd.doubleNested.diffStatus).toEqual(
+      "nested-add"
+    );
+  });
+
+  /**
+   * Test edge case: empty objects and arrays
+   */
+  test("empty object and array handling", () => {
+    const obj1 = {
+      emptyObj: {},
+      emptyArray: [],
+      data: { value: "test" },
+    };
+    const obj2 = {
+      emptyObj: { newProp: "added" },
+      emptyArray: ["newItem"],
+      data: {},
+    };
+
+    const result = annotateDiffTree(obj1, obj2);
+    const diffTree = result.diffTree;
+
+    expect(diffTree.diffStatus).toEqual("contains-nested-changes");
+    expect(diffTree.emptyObj.diffStatus).toEqual("contains-changes");
+    expect(diffTree.emptyArray.diffStatus).toEqual("contains-changes");
+    expect(diffTree.data.diffStatus).toEqual("contains-changes");
   });
 });

--- a/frontend/src/tests/diffUtils.test.ts
+++ b/frontend/src/tests/diffUtils.test.ts
@@ -46,7 +46,9 @@ var obj2: astNode = {
     items: {},
   },
   add: {
-    nestedAdd: {},
+    nestedAdd: {
+      doubleNested: {}
+    },
   },
 };
 // const expectedChildChanges = new Map<string, any[]>(); // map path to [# of expected childChanges, childChange keys]
@@ -114,6 +116,7 @@ describe("diffUtils test", () => {
     testChildChanges("", true, 3, ["unnestedText", "removedText", "add"]);
     testChildChanges("array.items", false, 1, ["array.items.0"]);
     testChildChanges("unnestedText", false, 0, []);
+    testChildChanges("add", false, 0, []);
   });
 
   /**
@@ -188,5 +191,6 @@ describe("diffUtils test", () => {
     expect(diffTree.array.diffStatus).toEqual("contains-nested-changes");
     expect(diffTree.add.diffStatus).toEqual("added");
     expect(diffTree.add.nestedAdd.diffStatus).toEqual("nested-add");
+    expect(diffTree.add.nestedAdd.doubleNested.diffStatus).toEqual("nested-add");
   });
 });

--- a/frontend/src/tests/diffUtils.test.ts
+++ b/frontend/src/tests/diffUtils.test.ts
@@ -1,0 +1,192 @@
+import {
+  getDirectChildChanges,
+  setChildChanges,
+  buildChangeMap,
+  annotateDiffTree,
+} from "../diffUtils";
+import { diff } from "json-diff-ts";
+import { JsonDiffChange } from "../typesAndInterfaces";
+import exp from "constants";
+
+const getChangeMap = (obj1: any, obj2: any): Map<string, JsonDiffChange> => {
+  const changes = diff(obj1, obj2);
+  const changeMap = new Map<string, JsonDiffChange>();
+  buildChangeMap(changes, "", changeMap);
+  return changeMap;
+};
+type astNode = {
+  [key: string]: any;
+};
+
+var obj1: astNode = {
+  value: {
+    text: "a",
+    doubleNest: {
+      a: 1,
+    },
+  },
+  unnestedText: "b",
+  array: {
+    items: {
+      0: "a",
+    },
+  },
+  removedText: "bye",
+};
+var obj2: astNode = {
+  value: {
+    text: "b",
+    doubleNest: {
+      a: 2,
+    },
+    newText: "a",
+  },
+  unnestedText: "a",
+  array: {
+    items: {},
+  },
+  add: {
+    nestedAdd: {},
+  },
+};
+// const expectedChildChanges = new Map<string, any[]>(); // map path to [# of expected childChanges, childChange keys]
+// expectedChildChanges.set("", [2, "unnestedText", "removedText"]);
+// expectedChildChanges.set("value", [2, "value.text", "value.newText"]);
+// expectedChildChanges.set("value.doubleNest", [1, "value.doubleNest.a"]);
+// expectedChildChanges.set("array", [1, "array.0"]);
+// expectedChildChanges.set("unnestedText", [0]);
+// expectedChildChanges.set("removedText", [0]);
+
+const changeMap = getChangeMap(obj1, obj2);
+
+const testChildChanges = (
+  nodePath: string,
+  expectedDescendantChanges: boolean,
+  expectedChildChanges: number,
+  expectedChildPaths: string[]
+) => {
+  const [childChanges, anyDescendantChanges] = getDirectChildChanges(
+    nodePath,
+    changeMap
+  );
+  expect(anyDescendantChanges).toBe(expectedDescendantChanges);
+  expect(childChanges.length).toBe(expectedChildChanges);
+  expectedChildPaths.forEach((path) => {
+    expect(childChanges.includes(path)).toEqual(true);
+  });
+};
+
+describe("diffUtils test", () => {
+  // takes json-diff-ts diff output and flatten to nodePath -> change
+  // we can test by manually constructing objects (ob1 -> obj2), getting diff, building changeMap. Then check that changeMap contains the paths we manually change in obj construction
+  // essentially want to ensure that paths are correct,
+  test("buildChangeMap", () => {
+    // expectedChildChanges.forEach((nodeChildChanges, nodePath) => {
+    //   if (nodeChildChanges[0] > 0) {
+    //     expect(changeMap.get(nodePath)).toBeUndefined();
+    //     nodeChildChanges.forEach((changePath) => {
+    //       if (typeof changePath === "string") {
+    //         expect(changeMap.get(changePath)).toBeDefined();
+    //       }
+    //     });
+    //   }
+    // });
+    expect(changeMap.get("value.text")).toBeDefined();
+    expect(changeMap.get("value.text")?.type).toEqual("UPDATE");
+    expect(changeMap.get("value.doubleNest.a")).toBeDefined();
+    expect(changeMap.get("value.doubleNest.a")?.type).toEqual("UPDATE");
+    expect(changeMap.get("value.newText")).toBeDefined();
+    expect(changeMap.get("value.newText")?.type).toEqual("ADD");
+    expect(changeMap.get("unnestedText")).toBeDefined();
+    expect(changeMap.get("unnestedText")?.type).toEqual("UPDATE");
+    expect(changeMap.get("array.items.0")).toBeDefined();
+    expect(changeMap.get("array.items.0")?.type).toEqual("REMOVE");
+    expect(changeMap.get("removedText")).toBeDefined();
+    expect(changeMap.get("removedText")?.type).toEqual("REMOVE");
+    expect(changeMap.get("add")).toBeDefined();
+    expect(changeMap.get("add")?.type).toEqual("ADD");
+  });
+
+  // given a nodePath, and changemap, returns array of paths with child changes
+  test("getDirectChildChanges", () => {
+    testChildChanges("value", true, 2, ["value.text", "value.newText"]);
+    testChildChanges("value.doubleNest", false, 1, ["value.doubleNest.a"]);
+    testChildChanges("", true, 3, ["unnestedText", "removedText", "add"]);
+    testChildChanges("array.items", false, 1, ["array.items.0"]);
+    testChildChanges("unnestedText", false, 0, []);
+  });
+
+  /**
+   * can test couple of things for setChildChanges:
+   *    removals are injected properly to passed node
+   *    expected changes all exist
+   */
+  test("setChildChanges", () => {
+    const tmpObj2 = JSON.parse(JSON.stringify(obj2));
+    // testing on root object
+    setChildChanges(
+      tmpObj2,
+      "",
+      ["removedText", "unnestedText", "add"],
+      changeMap
+    );
+    expect(tmpObj2.childChanges).toBeDefined();
+    expect(Object.keys(tmpObj2.childChanges).length).toEqual(3);
+    expect(tmpObj2.removedText).toBeDefined(); // expect removals to inject
+    expect(tmpObj2.childChanges.removedText).toBeDefined();
+    expect(tmpObj2.childChanges.unnestedText).toBeDefined();
+    expect(tmpObj2.childChanges.add).toBeDefined();
+    expect(tmpObj2.childChanges.removedText.type).toEqual("REMOVE");
+    expect(tmpObj2.childChanges.unnestedText.type).toEqual("UPDATE");
+    expect(tmpObj2.childChanges.add.type).toEqual("ADD");
+
+    // testing on obj.value
+    setChildChanges(
+      tmpObj2.value,
+      "value",
+      ["value.text", "value.newText"],
+      changeMap
+    );
+    expect(tmpObj2.value.childChanges).toBeDefined();
+    expect(Object.keys(tmpObj2.value.childChanges).length).toEqual(2);
+    expect(tmpObj2.value.childChanges.text).toBeDefined();
+    expect(tmpObj2.value.childChanges.newText).toBeDefined();
+    expect(tmpObj2.value.childChanges.text.type).toEqual("UPDATE");
+    expect(tmpObj2.value.childChanges.newText.type).toEqual("ADD");
+
+    // testing on obj.array
+    setChildChanges(
+      tmpObj2.array.items,
+      "array.items",
+      ["array.items.0"],
+      changeMap
+    );
+    expect(tmpObj2.array.items[0]).toBeDefined();
+    expect(tmpObj2.array.items.childChanges).toBeDefined();
+    expect(Object.keys(tmpObj2.array.items.childChanges).length).toEqual(1);
+    expect(tmpObj2.array.items.childChanges[0]).toBeDefined();
+    expect(tmpObj2.array.items.childChanges[0].type).toEqual("REMOVE");
+  });
+
+  /**
+   * diff ob1 -> obj2
+   * verify removals exist in obj2
+   * verify all changes have correct statuses
+   */
+  test("annotateDiffTree", () => {
+    const annotations = annotateDiffTree(obj1, obj2);
+    const diffTree = annotations.diffTree;
+
+    // expect removed nodes to exist in the tree
+    expect(diffTree.removedText).toBeDefined();
+    expect(diffTree.array.items[0]).toBeDefined();
+
+    // expect node to have proper statuses
+    expect(diffTree.diffStatus).toEqual("contains-changes");
+    expect(diffTree.value.diffStatus).toEqual("contains-changes");
+    expect(diffTree.value.doubleNest.diffStatus).toEqual("contains-changes");
+    expect(diffTree.array.diffStatus).toEqual("contains-nested-changes");
+    expect(diffTree.add.diffStatus).toEqual("added");
+    expect(diffTree.add.nestedAdd.diffStatus).toEqual("nested-add");
+  });
+});

--- a/frontend/src/typesAndInterfaces.ts
+++ b/frontend/src/typesAndInterfaces.ts
@@ -69,7 +69,6 @@ export interface JsonDiffChange {
   key: string;
   value?: any;
   oldValue?: any;
-  embeddedKey?: string | any;
   changes?: JsonDiffChange[]; // For nested changes
 }
 

--- a/lua_helpers/sort_by_position_table.lua
+++ b/lua_helpers/sort_by_position_table.lua
@@ -7,8 +7,10 @@ local function getNodePosition(node)
 		return node.location.begin.line, node.location.begin.column
 	end
 
-	if typeof(node) ~= "table" then return nil, nil end
-	
+	if typeof(node) ~= "table" then
+		return nil, nil
+	end
+
 	-- Recursive search for position in children
 	local minLine, minCol
 	for _, child in node do
@@ -34,11 +36,9 @@ local function getSortedChildren(node: any)
 	local sorted = {}
 	for key, child in node do
 		-- Filter out diff metadata and nodes without position
-		if key ~= "beforeValue" and key ~= "afterValue" then
-			local line, col = getNodePosition(child)
-			if line and col then
-				table.insert(sorted, child)
-			end
+		local line, col = getNodePosition(child)
+		if line and col then
+			table.insert(sorted, child)
 		end
 	end
 	table.sort(sorted, sortByPosition)

--- a/lua_helpers/temp_vendor/lute_printer.luau
+++ b/lua_helpers/temp_vendor/lute_printer.luau
@@ -238,7 +238,7 @@ function filterNodeForPrinting(node: any)
 end
 
 function printASTNode(astNode: any): string | nil
-	-- filter invalid nodes that are lefover from diff annotations
+	-- filter nodes lefover from diff annotations that we DONT want to print
 	astNode = filterNodeForPrinting(astNode)
 	local code, success
 	success, code = pcall(function()
@@ -272,6 +272,7 @@ function printASTNode(astNode: any): string | nil
 end
 
 return {
+	filterNodeForPrinting = filterNodeForPrinting,
 	printfallback = printFallback,
 	printtoken = printtoken,
 	printlocal = printLocal,

--- a/lua_helpers/temp_vendor/lute_printer.luau
+++ b/lua_helpers/temp_vendor/lute_printer.luau
@@ -46,7 +46,6 @@ local function printFallback(node: any): string
 	else
 		local sortedChildren = getSortedChildren(node)
 		for key, child in sortedChildren do
-			-- print("printing child", key, child)
 			nodeSrcStr ..= printASTNode(child) or ""
 		end
 	end
@@ -217,7 +216,30 @@ function printType(node: luau.AstType): string
 	return buffer.readstring(printer.result, 0, printer.cursor)
 end
 
+function filterNodeForPrinting(node: any)
+	local filtered = {}
+	if typeof(node) == "table" then
+		for k, v in node do
+			if
+				(type(v) == "table" and v.diffStatus == "removed")
+				or k == "childChanges"
+				or k == "beforeValue"
+				or k == "afterValue"
+			then
+				continue
+			end
+			if typeof(v) == "table" then
+				v = filterNodeForPrinting(v)
+			end
+			filtered[k] = v
+		end
+	end
+	return filtered
+end
+
 function printASTNode(astNode: any): string | nil
+	-- filter invalid nodes that are lefover from diff annotations
+	astNode = filterNodeForPrinting(astNode)
 	local code, success
 	success, code = pcall(function()
 		return printStatement(astNode)

--- a/lua_helpers/type_annotations.lua
+++ b/lua_helpers/type_annotations.lua
@@ -137,7 +137,6 @@ local typeDefinitions = {
 		["varargAnnotation"] = "AstTypePack",
 		["returnAnnotation"] = "AstTypePack",
 		["returnTypes"] = "AstTypePack",
-		["vararg"] = "AstTypePack",
 		["tailType"] = "AstTypePack",
 
 		-- Special properties

--- a/lua_tests/printASTNode.spec.lua
+++ b/lua_tests/printASTNode.spec.lua
@@ -5,6 +5,45 @@ local getSortedChildren = require("../lua_helpers/sort_by_position_table")
 local printLocalCases = helpers.testCases.printLocalCases
 local createMockToken, createMockPunctuatedArray = helpers.createMockToken, helpers.createMockPunctuatedArray
 
+-- want to test that invalid node types are removed; and specifically, that nested invalid nodes are removed (i.e a nested "REMOVE" node)
+local function test_filternode()
+	local node = {
+		beforeValue = {
+			nested = {
+				[0] = {
+					a = 1,
+				},
+			},
+		},
+		afterValue = {
+			nested = {},
+		},
+		childChanges = {
+			["nested.0"] = {
+				type = "REMOVE",
+			},
+		},
+		nested = {
+			[0] = {
+				a = 1,
+				diffStatus = "removed",
+			},
+			childChanges = {
+				["nested.0"] = {
+					type = "remove",
+				},
+			},
+		},
+	}
+	local filtered = printer.filterNodeForPrinting(node)
+	assert(filtered.nested ~= nil, "Incorrectly filtered valid prop")
+	assert(filtered.beforeValue == nil, "Failed to filter node")
+	assert(filtered.afterValue == nil, "Failed to filter node")
+	assert(filtered.childChanges == nil, "Failed to filter node")
+	assert(filtered.nested[0] == nil, "Failed to filter nested invalid props from node")
+	assert(filtered.nested.childChanges == nil, "Failed to filter nested invalid props from node")
+end
+
 local function test_printlocal()
 	for expectedOutput, testCase in printLocalCases do
 		local result = printer.printlocal(testCase)
@@ -152,6 +191,7 @@ end
 -- Main test runner
 return function()
 	print("Running printASTNode comprehensive tests...")
+	test_filternode()
 	test_printlocal()
 	test_printfallback()
 	test_position_sorting()


### PR DESCRIPTION
## Problem

Removed nodes don't currently show up in the diff mode output. This is because we annotate the AST of the second code snippet, in which the removed nodes don't actually exist.

## Solution

Leverage exist annotation logic, which can determine child changes for a node by comparing the node path against the changemap paths (changemap contains nodePath -> change pairs)

When computing a node's `childChanges`  property using the paths of its changed children, we inject a child into the node if it's change type is `REMOVE`.

To better support printing of diff-annotated nodes (which can contain removed properties and other excess from annotation), we filter nodes in `printASTNode`.

This PR also adds (much needed) tests for:
- `diffUtils`
- the new `filterNodeForPrinting` function