### PR TITLE
#feat add type annotations for removed keys and node type diff display

### DIFF
--- a/.changes/38-feat.md
+++ b/.changes/38-feat.md
@@ -1,1 +1,1 @@
-add type annotations for removed keys and node type diff display
+add type annotations for removed keys and node type before->after display

--- a/.changes/38-feat.md
+++ b/.changes/38-feat.md
@@ -1,0 +1,1 @@
+add type annotations for removed keys and node type diff display

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -227,7 +227,6 @@
 .diff-arrow {
   color: var(--vscode-gitDecoration-modifiedResourceForeground, #3490dc);
   font-weight: bold;
-  margin: 0 4px;
 }
 
 .diff-after {
@@ -409,7 +408,12 @@
   transition: color 0.15s ease, opacity 0.15s ease, border-color 0.15s ease;
 }
 
-.prev-type {
+.type-annotation.has-prev-type {
+  font-weight: bold;
+  color: var(--vscode-gitDecoration-addedResourceForeground, #28a745);
+}
+
+.unchanged {
   margin-left: 2%;
 }
 

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -409,6 +409,10 @@
   transition: color 0.15s ease, opacity 0.15s ease, border-color 0.15s ease;
 }
 
+.prev-type {
+  margin-left: 2%;
+}
+
 .type-annotation:hover,
 .type-annotation:focus-visible {
   color: var(--vscode-textLink-foreground, #007acc);

--- a/frontend/src/TreeNode.tsx
+++ b/frontend/src/TreeNode.tsx
@@ -86,7 +86,7 @@ export const TreeNode: React.FC<TreeNodeProps> = ({
         ></TypeAnnotation>
       );
 
-      if (type !== prevType) {
+      if (type !== prevType && prevType) {
         // if type ~= prevType, display type before/after very similar to how we display value before/after...
         return (
           <React.Fragment>
@@ -449,12 +449,6 @@ export const TreeNode: React.FC<TreeNodeProps> = ({
             value.childChanges[key] &&
             value.childChanges[key].type === "REMOVE"
           ) {
-            console.log(
-              "Setting type definition for removed node:",
-              key,
-              prevTypeDefinition,
-              prevType
-            );
             childPropertyDefinition = prevTypeDefinition?.properties?.find(
               (prop) => prop.name === key
             );
@@ -522,14 +516,12 @@ const TreeNodeContainer: React.FC<TreeNodeContainerProps> = (props) => {
     const childChanges = props.value.childChanges;
     if (childChanges && (childChanges._astType || childChanges.kind)) {
       const hackVal = {
-        _astType: childChanges._astType
-          ? childChanges._astType.oldValue
-          : undefined,
-        kind: childChanges.kind ? childChanges.kind.oldValue : undefined,
+        _astType: childChanges._astType ? childChanges._astType.oldValue : type, // might need to handle removed ast types here better; (generally scenarios other than UPDATE _astType)
+        kind: childChanges.kind ? childChanges.kind.oldValue : kind,
       };
-      return getTypeString(hackVal, props.nodeKey, undefined); // don't want to use
+      return getTypeString(hackVal, props.nodeKey, undefined);
     }
-    return [type, kind]; // if type not in changes, return already computed (prevType is same as currentType)
+    return [type, kind]; // if _astType not in changes, return already computed (prevType is same as currentType)
   }, [type, kind, props.value, props.nodeKey]);
   const [prevTypeDefinition, prevArrayType] = React.useMemo(() => {
     if (prevType) {

--- a/frontend/src/TreeNode.tsx
+++ b/frontend/src/TreeNode.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from "react";
+import React from "react";
 import { TypeAnnotation } from "./components/TypeAnnotation";
 import { shouldAutoCollapse } from "./nodeEmphasisHelpers";
 import { JSX } from "react/jsx-runtime";

--- a/frontend/src/TreeNode.tsx
+++ b/frontend/src/TreeNode.tsx
@@ -110,7 +110,16 @@ export const TreeNode: React.FC<TreeNodeProps> = ({
       }
     }
     return null;
-  }, [type, arrayType, typeDefinition, kind]);
+  }, [
+    type,
+    arrayType,
+    typeDefinition,
+    kind,
+    prevType,
+    prevTypeDefinition,
+    prevArrayType,
+    prevKind,
+  ]);
 
   // Get diff-specific styling
   const getDiffClassName = React.useCallback(() => {

--- a/frontend/src/TreeNode.tsx
+++ b/frontend/src/TreeNode.tsx
@@ -512,6 +512,7 @@ const TreeNodeContainer: React.FC<TreeNodeContainerProps> = (props) => {
 
   const autoCollapse = props.isDiffMode
     ? props.diffStatus === "unchanged" ||
+      props.diffStatus === "removed" ||
       shouldAutoCollapse(type, typeDefinition)
     : shouldAutoCollapse(type, typeDefinition);
 

--- a/frontend/src/components/TypeAnnotation.tsx
+++ b/frontend/src/components/TypeAnnotation.tsx
@@ -15,19 +15,25 @@ export const TypeAnnotation: React.FC<TypeAnnotationProps> = ({
   typeDefinition,
   isArrayType,
   kind,
-  hasPrevType = false
+  hasPrevType = false,
 }) => {
   return (
     <span className="ast-annotations">
-      <TypeTooltip
-        key="type"
-        typeName={typeName}
-        typeDefinition={typeDefinition}
-        arrayType={isArrayType}
-        kind={kind}
-      >
-        <span className={`type-annotation ${hasPrevType ? "" : "prev-type"}`}>(type: {typeName})</span>
-      </TypeTooltip>
+      <span className={`${hasPrevType ? "" : "unchanged"}`}>
+        <TypeTooltip
+          key="type"
+          typeName={typeName}
+          typeDefinition={typeDefinition}
+          arrayType={isArrayType}
+          kind={kind}
+        >
+          <span
+            className={`type-annotation ${hasPrevType ? "has-prev-type" : ""}`}
+          >
+            type: {typeName}
+          </span>
+        </TypeTooltip>
+      </span>
     </span>
   );
 };

--- a/frontend/src/components/TypeAnnotation.tsx
+++ b/frontend/src/components/TypeAnnotation.tsx
@@ -7,6 +7,7 @@ export interface TypeAnnotationProps {
   typeDefinition?: ASTTypeDefinition;
   isArrayType: boolean;
   kind: string;
+  hasPrevType?: boolean;
 }
 
 export const TypeAnnotation: React.FC<TypeAnnotationProps> = ({
@@ -14,6 +15,7 @@ export const TypeAnnotation: React.FC<TypeAnnotationProps> = ({
   typeDefinition,
   isArrayType,
   kind,
+  hasPrevType = false
 }) => {
   return (
     <span className="ast-annotations">
@@ -24,7 +26,7 @@ export const TypeAnnotation: React.FC<TypeAnnotationProps> = ({
         arrayType={isArrayType}
         kind={kind}
       >
-        <span className="type-annotation"> (type: {typeName})</span>
+        <span className={`type-annotation ${hasPrevType ? "" : "prev-type"}`}>(type: {typeName})</span>
       </TypeTooltip>
     </span>
   );

--- a/frontend/src/utils/astTypeDefinitions.ts
+++ b/frontend/src/utils/astTypeDefinitions.ts
@@ -17,6 +17,17 @@ export interface GenericTypeDefinition {
   genericType: string;
 }
 
+export interface TypeMetadata {
+  type: string;
+  typeDefinition: ASTTypeDefinition | undefined;
+  arrayType: boolean;
+  kind: string;
+  prevType: string;
+  prevTypeDefinition: ASTTypeDefinition | undefined;
+  prevArrayType: boolean;
+  prevKind: string;
+}
+
 export const astTypeDefinitions: Record<string, ASTTypeDefinition> = {
   // === UTILITY TYPES ===
   Position: {

--- a/frontend/src/utils/astTypeHelpers.ts
+++ b/frontend/src/utils/astTypeHelpers.ts
@@ -4,7 +4,6 @@ import {
   ASTTypeDefinition,
   GenericTypeDefinition,
   astTypeDefinitions,
-  PropertyDefinition,
   TypeMetadata,
 } from "./astTypeDefinitions";
 

--- a/frontend/src/utils/astTypeHelpers.ts
+++ b/frontend/src/utils/astTypeHelpers.ts
@@ -1,6 +1,12 @@
 // Comprehensive Luau AST Type Definitions
 // Generated from official Luau type definitions for maximum accuracy
-import { ASTTypeDefinition, GenericTypeDefinition, astTypeDefinitions } from "./astTypeDefinitions";
+import {
+  ASTTypeDefinition,
+  GenericTypeDefinition,
+  astTypeDefinitions,
+  PropertyDefinition,
+  TypeMetadata,
+} from "./astTypeDefinitions";
 
 export function getTypeDefinition(
   typeName: string | GenericTypeDefinition
@@ -119,7 +125,9 @@ export const unpackArrayType = (type: string): string => {
 };
 
 // Parse generic types like "Pair<AstExpr>" -> { baseType: "Pair", genericType: "AstExpr" }
-export const parseGenericType = (type: string): GenericTypeDefinition | undefined => {
+export const parseGenericType = (
+  type: string
+): GenericTypeDefinition | undefined => {
   const match = type.match(/^(\w+)<(.+)>$/);
   if (match) {
     return { baseType: match[1], genericType: match[2] };
@@ -144,7 +152,9 @@ export const getTypeString = (
   return [type, kind];
 };
 
-export const getType = (type: string): [ASTTypeDefinition | undefined, boolean] => {
+export const getType = (
+  type: string
+): [ASTTypeDefinition | undefined, boolean] => {
   const genericTypeInfo = Array.isArray(type)
     ? undefined
     : parseGenericType(type);
@@ -155,4 +165,26 @@ export const getType = (type: string): [ASTTypeDefinition | undefined, boolean] 
     ? genericTypeInfo
     : type;
   return [getTypeDefinition(unpackedType), isArray];
+};
+
+export const getChildPropertyDefinition = (
+  typeMetadata: TypeMetadata,
+  childChanges: any,
+  childKey: string
+) => {
+  if (
+    childChanges &&
+    childChanges[childKey] &&
+    childChanges[childKey].type === "REMOVE"
+  ) {
+    // handle childPropertyDefinition differently when node is removed; since in object case, this implies a key no longer exists, it indicates the node type has changed
+    // so we need to ensure the childPropertyDefinition is adjusted appopriately given it was a child of the previous node value
+    return typeMetadata.prevTypeDefinition?.properties?.find(
+      (prop) => prop.name === childKey
+    );
+  } else {
+    return typeMetadata.typeDefinition?.properties?.find(
+      (prop) => prop.name === childKey
+    );
+  }
 };


### PR DESCRIPTION
## Problem

For nodes that do not have a type-annotation (no `_astType` property), we fallback on `parentInferredType` during `TreeNode` rendering. The `parentInferredType` is computed by finding the child's key in the parents type definition; specifically, we check `parentTypeDefinition.properties[childKey]`. If it exists, we can use the metadata to infer the child's type.

If we are using the current approach for a removed child (specifically when the parent is an object, so the removed child indicates a key was removed and the parent type has changed), `parentTypeDefinition.properties[childKey]` will always be nil. Thus, the current system will fail to annotate removed nodes with no default type annotation.

## Solution

We can resolve this by computing previous type metadata for each `TreeNode`. To do this, we can check a node's `childChanges` for an `_astType` change and use the corresponding information if it exists.

Then, if a child key is removed, we can infer the `childPropertyDefinition` and `parentInferredType` by checking against the `prevTypeDefinition`'s properties.

Since this fix adds previous type information, we can also leverage it to display a ~before~->after annotation for types (similar to how an updated value is shown in the diff)