### PR TITLE
#chore Separate TreeNode and TreeNodeContainer

### DIFF
--- a/frontend/src/components/DiffAnalyzer.tsx
+++ b/frontend/src/components/DiffAnalyzer.tsx
@@ -2,7 +2,7 @@ import CodeEditor from "./CodeEditor";
 import FilterDropdown from "./filterDropdown";
 import { parseDiff } from "../utils/parsingMessageHandlers";
 import { ASTNode, VSCodeAPI } from "../types/typesAndInterfaces";
-import TreeNodeContainer from "./TreeNode";
+import TreeNodeContainer from "./TreeNodeContainer";
 
 interface DiffAnalyzerProps {
   codeSnippet1: string;

--- a/frontend/src/components/LiveEditor.tsx
+++ b/frontend/src/components/LiveEditor.tsx
@@ -2,7 +2,7 @@ import CodeEditor from "./CodeEditor";
 import FilterDropdown from "./filterDropdown";
 import { parseAST } from "../utils/parsingMessageHandlers";
 import { VSCodeAPI, ASTNode } from "../types/typesAndInterfaces";
-import TreeNodeContainer from "./TreeNode";
+import TreeNodeContainer from "./TreeNodeContainer";
 
 interface LiverEditorProps {
   codeSnippet1: string;

--- a/frontend/src/components/TreeNode.tsx
+++ b/frontend/src/components/TreeNode.tsx
@@ -453,20 +453,6 @@ export const TreeNode: React.FC<TreeNodeProps> = ({
             },
             key
           );
-
-          // return (
-          //   <TreeNodeContainer
-          //     key={key}
-          //     nodeKey={key}
-          //     value={childValue}
-          //     level={level + 1}
-          //     parentInferredType={parentInferredType}
-          //     searchTerm={searchTerm}
-          //     hiddenNodes={hiddenNodes}
-          //     path={`${path}.${key}`}
-          //     {...childDiffProps}
-          //   />
-          // );
         })}
     </div>
   );

--- a/frontend/src/components/TreeNode.tsx
+++ b/frontend/src/components/TreeNode.tsx
@@ -20,7 +20,7 @@ interface TreeNodeProps {
   renderChild: (
     childProps: TreeNodeContainerProps,
     key: string | number
-  ) => React.ReactNode;
+  ) => React.ReactElement;
   typeMetadata: TypeMetadata;
   searchTerm?: string;
   isDiffMode?: boolean;

--- a/frontend/src/components/TreeNode.tsx
+++ b/frontend/src/components/TreeNode.tsx
@@ -6,8 +6,7 @@ import {
   getChildPropertyDefinition,
 } from "../utils/astTypeHelpers";
 import { CodeTooltip } from "./CodeTooltip";
-import TreeNodeContainer, { TreeNodeContainerProps } from "./TreeNodeContainer";
-
+import { TreeNodeContainerProps } from "../types/typesAndInterfaces";
 import { TypeMetadata } from "../utils/astTypeDefinitions";
 import { useCodeTranslationContext } from "../context/codeTranslationContext";
 

--- a/frontend/src/components/TreeNodeContainer.tsx
+++ b/frontend/src/components/TreeNodeContainer.tsx
@@ -1,0 +1,102 @@
+import { getTypeString, getType } from "../utils/astTypeHelpers";
+import React from "react";
+import TreeNode from "./TreeNode";
+import { shouldAutoCollapse } from "../utils/nodeEmphasisHelpers";
+
+// Container component that manages expand/collapse state for each node
+export interface TreeNodeContainerProps {
+  nodeKey: string;
+  value: any;
+  level: number;
+  path: string;
+  searchTerm?: string;
+  parentInferredType?: string | string[];
+  isDiffMode?: boolean;
+  diffStatus?:
+    | "added"
+    | "nested-add"
+    | "removed"
+    | "updated"
+    | "unchanged"
+    | "contains-changes"
+    | "contains-nested-changes";
+  beforeValue?: any;
+  afterValue?: any;
+  hiddenNodes?: string[];
+}
+
+const TreeNodeContainer: React.FC<TreeNodeContainerProps> = (props) => {
+  // get all this metadata at tree node level; pass to TypeTooltip
+  const [type, kind] = React.useMemo(() => {
+    return getTypeString(props.value, props.nodeKey, props.parentInferredType);
+  }, [props.value, props.nodeKey, props.parentInferredType]);
+
+  const [typeDefinition, arrayType] = React.useMemo(() => {
+    if (type) {
+      return getType(type);
+    }
+    return [undefined, false];
+  }, [type]);
+
+  // do the above once each for old and new values on contains-changes nodes
+  const [prevType, prevKind] = React.useMemo(() => {
+    const childChanges = props.value ? props.value.childChanges : undefined;
+    if (childChanges && (childChanges._astType || childChanges.kind)) {
+      const hackVal = {
+        _astType: childChanges._astType ? childChanges._astType.oldValue : type, // might need to handle removed ast types here better; (generally scenarios other than UPDATE _astType)
+        kind: childChanges.kind ? childChanges.kind.oldValue : kind,
+      };
+      return getTypeString(hackVal, props.nodeKey, undefined);
+    }
+    return [type, kind]; // if _astType not in changes, return already computed (prevType is same as currentType)
+  }, [type, kind, props.value, props.nodeKey]);
+  const [prevTypeDefinition, prevArrayType] = React.useMemo(() => {
+    if (prevType) {
+      return getType(prevType);
+    }
+    return [undefined, false];
+  }, [prevType]);
+
+  const typeMetadata = {
+    type: type,
+    typeDefinition: typeDefinition,
+    arrayType: arrayType,
+    kind: kind,
+    prevType: prevType,
+    prevTypeDefinition: prevTypeDefinition,
+    prevArrayType: prevArrayType,
+    prevKind: prevKind,
+  };
+
+  const autoCollapse = props.isDiffMode
+    ? props.diffStatus === "unchanged" ||
+      props.diffStatus === "removed" ||
+      shouldAutoCollapse(type, typeDefinition)
+    : shouldAutoCollapse(type, typeDefinition);
+
+  const [expanded, setExpanded] = React.useState(!autoCollapse);
+
+  const handleToggle = () => {
+    setExpanded(!expanded);
+  };
+
+  // Hide nodes that are in the hidden nodes list (when filtering is active)
+  if (props.hiddenNodes && props.hiddenNodes.includes(props.nodeKey)) {
+    return null;
+  }
+
+  return (
+    <TreeNode
+      {...props}
+      expanded={expanded}
+      onToggle={handleToggle}
+      typeMetadata={typeMetadata}
+      renderChild={(
+        childProps: TreeNodeContainerProps,
+        key: string | number
+      ) => <TreeNodeContainer {...childProps} key={key} />}
+    />
+  );
+};
+
+export default TreeNodeContainer;

--- a/frontend/src/components/TreeNodeContainer.tsx
+++ b/frontend/src/components/TreeNodeContainer.tsx
@@ -1,56 +1,8 @@
-import { getTypeString, getType } from "../utils/astTypeHelpers";
 import React from "react";
 import TreeNode from "./TreeNode";
 import { shouldAutoCollapse } from "../utils/nodeEmphasisHelpers";
 import { TreeNodeContainerProps } from "../types/typesAndInterfaces";
-
-/**
- * Custom hook to compute type metadata for tree nodes.
- * Handles both current and previous type information for diff mode.
- */
-const useTypeMetadata = (props: TreeNodeContainerProps) => {
-  const [type, kind] = React.useMemo(() => {
-    return getTypeString(props.value, props.nodeKey, props.parentInferredType);
-  }, [props.value, props.nodeKey, props.parentInferredType]);
-
-  const [typeDefinition, arrayType] = React.useMemo(() => {
-    if (type) {
-      return getType(type);
-    }
-    return [undefined, false];
-  }, [type]);
-
-  // Compute previous type metadata for diff mode
-  const [prevType, prevKind] = React.useMemo(() => {
-    const childChanges = props.value?.childChanges;
-    if (childChanges && (childChanges._astType || childChanges.kind)) {
-      const hackVal = {
-        _astType: childChanges._astType ? childChanges._astType.oldValue : type,
-        kind: childChanges.kind ? childChanges.kind.oldValue : kind,
-      };
-      return getTypeString(hackVal, props.nodeKey, undefined);
-    }
-    return [type, kind];
-  }, [type, kind, props.value, props.nodeKey]);
-
-  const [prevTypeDefinition, prevArrayType] = React.useMemo(() => {
-    if (prevType) {
-      return getType(prevType);
-    }
-    return [undefined, false];
-  }, [prevType]);
-
-  return {
-    type,
-    typeDefinition,
-    arrayType,
-    kind,
-    prevType,
-    prevTypeDefinition,
-    prevArrayType,
-    prevKind,
-  };
-};
+import { useTypeMetadata } from "../hooks/useTypeMetadata";
 
 const TreeNodeContainer: React.FC<TreeNodeContainerProps> = (props) => {
   const typeMetadata = useTypeMetadata(props);

--- a/frontend/src/components/TreeNodeContainer.tsx
+++ b/frontend/src/components/TreeNodeContainer.tsx
@@ -2,28 +2,7 @@ import { getTypeString, getType } from "../utils/astTypeHelpers";
 import React from "react";
 import TreeNode from "./TreeNode";
 import { shouldAutoCollapse } from "../utils/nodeEmphasisHelpers";
-
-// Container component that manages expand/collapse state for each node
-export interface TreeNodeContainerProps {
-  nodeKey: string;
-  value: any;
-  level: number;
-  path: string;
-  searchTerm?: string;
-  parentInferredType?: string | string[];
-  isDiffMode?: boolean;
-  diffStatus?:
-    | "added"
-    | "nested-add"
-    | "removed"
-    | "updated"
-    | "unchanged"
-    | "contains-changes"
-    | "contains-nested-changes";
-  beforeValue?: any;
-  afterValue?: any;
-  hiddenNodes?: string[];
-}
+import { TreeNodeContainerProps } from "../types/typesAndInterfaces";
 
 const TreeNodeContainer: React.FC<TreeNodeContainerProps> = (props) => {
   // get all this metadata at tree node level; pass to TypeTooltip

--- a/frontend/src/hooks/useTypeMetadata.ts
+++ b/frontend/src/hooks/useTypeMetadata.ts
@@ -1,0 +1,56 @@
+import { getTypeString, getType } from "../utils/astTypeHelpers";
+import { TreeNodeContainerProps } from "../types/typesAndInterfaces";
+import React from "react";
+import { TypeMetadata } from "../utils/astTypeDefinitions";
+
+/**
+ * Custom hook to compute type metadata for tree nodes.
+ * Handles both current and previous type information for diff mode.
+ */
+export const useTypeMetadata = (
+  props: TreeNodeContainerProps
+): TypeMetadata => {
+  const [type, kind] = React.useMemo(() => {
+    return getTypeString(props.value, props.nodeKey, props.parentInferredType);
+  }, [props.value, props.nodeKey, props.parentInferredType]);
+
+  const [typeDefinition, arrayType] = React.useMemo(() => {
+    if (type) {
+      return getType(type);
+    }
+    return [undefined, false];
+  }, [type]);
+
+  // Compute previous type metadata for diff mode
+  const [prevType, prevKind] = React.useMemo(() => {
+    const childChanges = props.value?.childChanges;
+    const typeChanged =
+      childChanges && (childChanges._astType || childChanges.kind);
+    if (props.isDiffMode && typeChanged) {
+      const hackVal = {
+        _astType: childChanges._astType ? childChanges._astType.oldValue : type,
+        kind: childChanges.kind ? childChanges.kind.oldValue : kind,
+      };
+      return getTypeString(hackVal, props.nodeKey, undefined);
+    }
+    return [type, kind];
+  }, [type, kind, props.value, props.nodeKey, props.isDiffMode]);
+
+  const [prevTypeDefinition, prevArrayType] = React.useMemo(() => {
+    if (prevType) {
+      return getType(prevType);
+    }
+    return [undefined, false];
+  }, [prevType]);
+
+  return {
+    type,
+    typeDefinition,
+    arrayType,
+    kind,
+    prevType,
+    prevTypeDefinition,
+    prevArrayType,
+    prevKind,
+  };
+};

--- a/frontend/src/tests/TreeNode.test.tsx
+++ b/frontend/src/tests/TreeNode.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { render, screen, fireEvent, within } from "@testing-library/react";
 import "@testing-library/jest-dom";
-import TreeNodeContainer from "../components/TreeNode";
+import TreeNodeContainer from "../components/TreeNodeContainer";
 import { CodeTranslationContext } from "../context/codeTranslationContext";
 
 // Mock the context to avoid needing the full setup

--- a/frontend/src/tests/astTypeHelpers.test.ts
+++ b/frontend/src/tests/astTypeHelpers.test.ts
@@ -103,13 +103,13 @@ describe("astTypeHelpers", () => {
       "",
     ]);
 
-    // leverage getArrayType
+    // leverages getArrayType
     expect(getTypeString([{}], "entries")).toEqual([
       "{ AstExprTableItem }",
       "",
     ]);
 
-    // fallback on parentInferredType
+    // falls back on parentInferredType
     expect(
       getTypeString({ kind: "record" }, "[0]", "AstExprTableItem")
     ).toEqual(["AstExprTableItem", "record"]);

--- a/frontend/src/tests/useTypeMetadata.test.ts
+++ b/frontend/src/tests/useTypeMetadata.test.ts
@@ -1,0 +1,87 @@
+import { useTypeMetadata } from "../hooks/useTypeMetadata";
+import { TreeNodeContainerProps } from "../types/typesAndInterfaces";
+import { renderHook } from "@testing-library/react";
+import { astTypeDefinitions, TypeMetadata } from "../utils/astTypeDefinitions";
+
+// astTypeHelpers, upon which useTypeMetadata relies, are tested separately;
+// the goal here is not to test that the correct types are returned (since we assume astTypeHelpers work), but to test that useTypeMetadata behaves as expected
+//
+const defaultProps = {
+  nodeKey: "",
+  level: 0,
+  path: "",
+};
+
+const testHook = (props: TreeNodeContainerProps) => {
+  return renderHook((innerProps: TreeNodeContainerProps = props) =>
+    useTypeMetadata(innerProps)
+  );
+};
+
+const expectMatchingTypes = (result: TypeMetadata) => {
+  expect(result.type).toEqual(result.prevType);
+  expect(result.typeDefinition).toEqual(result.prevTypeDefinition);
+  expect(result.arrayType).toEqual(result.prevArrayType);
+  expect(result.kind).toEqual(result.prevKind);
+};
+
+describe("useTypeMetadata test", () => {
+  test("should work with default props", () => {
+    const { result } = testHook({
+      ...defaultProps,
+      value: { _astType: "_testType" },
+    });
+    expect(result.current).toBeDefined();
+    expect(result.current.type).toEqual("_testType");
+    expect(result.current.typeDefinition).toEqual(astTypeDefinitions._testType);
+  });
+
+  test("should re-compute metadata on prop change", () => {
+    const { result, rerender } = testHook({
+      ...defaultProps,
+      value: { _astType: "_testType" },
+    });
+    expect(result.current).toBeDefined();
+    const renderOneResult = result.current
+    expect(renderOneResult).toEqual(result.current);
+    rerender({ value: { _astType: "AstLocal" }, ...defaultProps });
+    expect(result.current).toBeDefined();
+    expect(result.current).not.toEqual(renderOneResult);
+  })
+
+  test("if not diffMode, prevTypeMetadata should equal typeMetadata", () => {
+    const { result } = testHook({
+      ...defaultProps,
+      value: { _astType: "_testType" },
+    });
+    expectMatchingTypes(result.current);
+  });
+
+  test("if diffMode and no child type change, prevTypeMetadata should equal typeMetadata", () => {
+    const { result } = testHook({
+      ...defaultProps,
+      isDiffMode: true,
+      value: { _astType: "_testType" },
+    });
+    expectMatchingTypes(result.current);
+  });
+
+  test("if diffMode and child type change, prevTypeMetadata should not equal typeMetadata", () => {
+    const { result } = testHook({
+      ...defaultProps,
+      isDiffMode: true,
+      value: {
+        _astType: "_testType",
+        childChanges: {
+          _astType: {
+            type: "UPDATE",
+            oldValue: "AstLocal",
+            value: "_testType",
+          },
+        },
+      },
+    });
+    expect(result.current.type).not.toEqual(result.current.prevType);
+    expect(result.current.type).not.toEqual(result.current.prevTypeDefinition);
+  });
+});

--- a/frontend/src/types/typesAndInterfaces.ts
+++ b/frontend/src/types/typesAndInterfaces.ts
@@ -91,3 +91,25 @@ export enum WindowMode {
   LiveEditor = "live-editor", // Window 1: Live code editor + AST
   DiffAnalyzer = "diff-analyzer", // Window 2: Code transformation diff
 }
+
+// Container component that manages expand/collapse state for each node
+export interface TreeNodeContainerProps {
+  nodeKey: string;
+  value: any;
+  level: number;
+  path: string;
+  searchTerm?: string;
+  parentInferredType?: string | string[];
+  isDiffMode?: boolean;
+  diffStatus?:
+    | "added"
+    | "nested-add"
+    | "removed"
+    | "updated"
+    | "unchanged"
+    | "contains-changes"
+    | "contains-nested-changes";
+  beforeValue?: any;
+  afterValue?: any;
+  hiddenNodes?: string[];
+};


### PR DESCRIPTION
## Problem

`TreeNode` and `TreeNodeContainer` are in the same file; it's a little messy and unreadable.
Also, the `typeMetadata` computation is disgusting and plainly in `TreeNodeContainer`

## Solution
Separate `TreeNode` and `TreeNodeContainer` into separate files; use a render child pattern to avoid circular dependency between the two.
Add a `useTypeMetadata` hook to extract the typeMetadata computation outside of `TreeNodeContainer`