### PR TITLE
#feat Collapse all children button for TreeNode

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -507,3 +507,39 @@
   color: var(--vscode-foreground);
   font-family: var(--vscode-editor-font-family);
 }
+
+.collapse-children-btn {
+  background: var(--vscode-button-secondaryBackground);
+  color: var(--vscode-button-secondaryForeground);
+  border: 1px solid var(--vscode-button-border, transparent);
+  border-radius: 3px;
+  padding: 2px 6px;
+  height: 20px;
+  min-width: 20px;
+  font-size: 11px;
+  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  margin-left: 8px;
+  box-shadow: none;
+  transition: all 0.2s ease;
+  vertical-align: middle;
+  font-family: var(--vscode-font-family);
+}
+
+.collapse-children-btn:hover:not(:disabled) {
+  background: var(--vscode-button-secondaryHoverBackground);
+  border-color: var(--vscode-button-border, var(--vscode-contrastActiveBorder));
+  transform: scale(1.05);
+}
+
+.collapse-children-btn:focus {
+  outline: 1px solid var(--vscode-focusBorder);
+  outline-offset: 1px;
+}
+
+.collapse-children-btn:active {
+  transform: scale(0.95);
+}

--- a/frontend/src/components/TreeNode.tsx
+++ b/frontend/src/components/TreeNode.tsx
@@ -22,6 +22,10 @@ interface TreeNodeProps {
     key: string | number
   ) => React.ReactElement;
   typeMetadata: TypeMetadata;
+  collapseAll: {
+    collapseAllButton: React.ReactElement,
+    collapsedChildren: boolean,
+  };
   searchTerm?: string;
   isDiffMode?: boolean;
   diffStatus?:
@@ -46,6 +50,7 @@ export const TreeNode: React.FC<TreeNodeProps> = ({
   onToggle,
   renderChild,
   typeMetadata,
+  collapseAll,
   searchTerm = "",
   isDiffMode = false,
   diffStatus = "unchanged",
@@ -271,6 +276,7 @@ export const TreeNode: React.FC<TreeNodeProps> = ({
           {renderDiffIndicator()}
           {renderValue}
           {renderTypeAnnotation ? renderTypeAnnotations() : null}
+          {collapseAll.collapseAllButton}
         </React.Fragment>
       );
     },
@@ -372,6 +378,7 @@ export const TreeNode: React.FC<TreeNodeProps> = ({
                 searchTerm: searchTerm,
                 path: `${path}.${index}`,
                 hiddenNodes: hiddenNodes,
+                forceCollapse: collapseAll.collapsedChildren,
                 ...childDiffProps,
               },
               index
@@ -448,6 +455,7 @@ export const TreeNode: React.FC<TreeNodeProps> = ({
               searchTerm: searchTerm,
               path: `${path}.${key}`,
               hiddenNodes: hiddenNodes,
+              forceCollapse: collapseAll.collapsedChildren,
               ...childDiffProps,
             },
             key

--- a/frontend/src/components/TreeNodeContainer.tsx
+++ b/frontend/src/components/TreeNodeContainer.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import React, { useEffect, useMemo } from "react";
 import TreeNode from "./TreeNode";
 import { shouldAutoCollapse } from "../utils/nodeEmphasisHelpers";
 import { TreeNodeContainerProps } from "../types/typesAndInterfaces";
@@ -17,17 +17,27 @@ const TreeNodeContainer: React.FC<TreeNodeContainerProps> = (props) => {
 
   const [expanded, setExpanded] = React.useState(!autoCollapse);
 
-  const [collapsedChildren, setCollapsedChildren] = React.useState(!autoCollapse);
+  useEffect(() => {
+    setExpanded(!autoCollapse);
+  }, [autoCollapse]);
 
-  const handleCollapseChildren = () => {
+  const [collapsedChildren, setCollapsedChildren] =
+    React.useState(autoCollapse);
+
+  const handleCollapseChildren = (e: React.MouseEvent) => {
+    e.stopPropagation(); // Prevents parent node click
     setCollapsedChildren(!collapsedChildren);
   };
 
   const collapseChildrenButton = useMemo(() => {
     return (
       // toggle children collapse
-      <button className="btn" onClick={handleCollapseChildren}>
-        {collapsedChildren ? "⬇️ Expand children?" : "➡️ Collapse children?"}
+      <button
+        className="collapse-children-btn"
+        onClick={handleCollapseChildren}
+        title={"Collapse all toggle"}
+      >
+        {collapsedChildren ? "⟲" : "⤴"}
       </button>
     );
   }, [collapsedChildren, handleCollapseChildren]);

--- a/frontend/src/components/TreeNodeContainer.tsx
+++ b/frontend/src/components/TreeNodeContainer.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 import TreeNode from "./TreeNode";
 import { shouldAutoCollapse } from "../utils/nodeEmphasisHelpers";
 import { TreeNodeContainerProps } from "../types/typesAndInterfaces";
@@ -7,13 +7,30 @@ import { useTypeMetadata } from "../hooks/useTypeMetadata";
 const TreeNodeContainer: React.FC<TreeNodeContainerProps> = (props) => {
   const typeMetadata = useTypeMetadata(props);
 
-  const autoCollapse = props.isDiffMode
-    ? props.diffStatus === "unchanged" ||
-      props.diffStatus === "removed" ||
-      shouldAutoCollapse(typeMetadata.type, typeMetadata.typeDefinition)
-    : shouldAutoCollapse(typeMetadata.type, typeMetadata.typeDefinition);
+  const autoCollapse =
+    props.forceCollapse ||
+    (props.isDiffMode
+      ? props.diffStatus === "unchanged" ||
+        props.diffStatus === "removed" ||
+        shouldAutoCollapse(typeMetadata.type, typeMetadata.typeDefinition)
+      : shouldAutoCollapse(typeMetadata.type, typeMetadata.typeDefinition));
 
   const [expanded, setExpanded] = React.useState(!autoCollapse);
+
+  const [collapsedChildren, setCollapsedChildren] = React.useState(!autoCollapse);
+
+  const handleCollapseChildren = () => {
+    setCollapsedChildren(!collapsedChildren);
+  };
+
+  const collapseChildrenButton = useMemo(() => {
+    return (
+      // toggle children collapse
+      <button className="btn" onClick={handleCollapseChildren}>
+        {collapsedChildren ? "⬇️ Expand children?" : "➡️ Collapse children?"}
+      </button>
+    );
+  }, [collapsedChildren, handleCollapseChildren]);
 
   const handleToggle = () => {
     setExpanded(!expanded);
@@ -34,6 +51,10 @@ const TreeNodeContainer: React.FC<TreeNodeContainerProps> = (props) => {
         childProps: TreeNodeContainerProps,
         key: string | number
       ) => <TreeNodeContainer {...childProps} key={key} />}
+      collapseAll={{
+        collapseAllButton: collapseChildrenButton,
+        collapsedChildren: collapsedChildren,
+      }}
     />
   );
 };

--- a/frontend/src/types/typesAndInterfaces.ts
+++ b/frontend/src/types/typesAndInterfaces.ts
@@ -98,6 +98,7 @@ export interface TreeNodeContainerProps {
   value: any;
   level: number;
   path: string;
+  forceCollapse?: boolean;
   searchTerm?: string;
   parentInferredType?: string | string[];
   isDiffMode?: boolean;


### PR DESCRIPTION
## Problem

Due to the verbose nature of AST nodes, the tree can quickly grow excessively large.

## Solution

Add a collapse children toggle to each node, that forces all children of the node to collapse for easier navigation.