### PR TITLE
#bug Remove unintended text area border on code input

### DIFF
--- a/.changes/49-bug.md
+++ b/.changes/49-bug.md
@@ -1,0 +1,1 @@
+Remove unintended text area border on code input

--- a/frontend/src/components/CodeEditor.css
+++ b/frontend/src/components/CodeEditor.css
@@ -8,7 +8,11 @@
   box-sizing: border-box;
 }
 
-/* Optional: focus ring like VS Code */
+.code-editor-viewport textarea {
+  outline: none !important;
+  box-shadow: none !important;   /* Safari/iOS blue glow */
+}
+
 .code-editor-viewport:focus-within {
   outline: 1px solid var(--vscode-focusBorder);
   outline-offset: 2px;

--- a/frontend/src/components/CodeEditor.tsx
+++ b/frontend/src/components/CodeEditor.tsx
@@ -25,9 +25,11 @@ const CodeEditor: React.FC<CodeEditorProps> = ({
         highlight={(code) => highlightLuauCode(code)}
         padding={8}
         preClassName="hljs lua"
+        textareaClassName=""
         placeholder={placeholder}
         // keep styles minimal—no height!
         style={{
+          border: "transparent",
           background: "transparent",
           fontFamily:
             'ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace',


### PR DESCRIPTION
## Problem

<img width="434" height="95" alt="Screenshot 2025-10-04 at 8 34 25 PM" src="https://github.com/user-attachments/assets/201a88f8-d939-4b49-9fce-91ccdadabb8f" />


## Solution

<img width="568" height="92" alt="Screenshot 2025-10-04 at 8 34 31 PM" src="https://github.com/user-attachments/assets/c65fdf3a-d984-41f0-bd23-c51208bfa417" />
