### PR TITLE
#bug nit styling improvements to code editor

### DIFF
--- a/.changes/53-bug.md
+++ b/.changes/53-bug.md
@@ -1,0 +1,1 @@
+nit styling improvements to code editor

--- a/frontend/src/components/CodeEditor.css
+++ b/frontend/src/components/CodeEditor.css
@@ -3,9 +3,10 @@
   background: var(--vscode-textCodeBlock-background);
   border: 1px solid var(--vscode-panel-border);
   border-radius: 4px;
-  padding: 8px; /* same inner padding as .ast-content */
+  padding: 4px;
   overflow: auto;
   box-sizing: border-box;
+  cursor: text;
 }
 
 .code-editor-viewport textarea {

--- a/frontend/src/components/CodeEditor.tsx
+++ b/frontend/src/components/CodeEditor.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useRef } from "react";
 import Editor from "react-simple-code-editor";
 import { highlightLuauCode } from "../utils/syntaxHighlighting";
 import "./CodeEditor.css";
@@ -16,10 +16,34 @@ const CodeEditor: React.FC<CodeEditorProps> = ({
   height = "320px",
   placeholder = "Enter your Luau code here...",
 }) => {
+  const editorRef = useRef<any>(null);
+
+  const handleContainerClick = (e: React.MouseEvent) => {
+    // Only focus if clicking on the container itself, not the editor content
+    if (e.target === e.currentTarget) {
+      // Try multiple ways to access the textarea
+      const container = e.currentTarget as HTMLElement;
+      const textarea = container.querySelector("textarea");
+      if (textarea) {
+        textarea.focus();
+      }
+    }
+  };
+
   return (
-    <div className="code-editor-viewport" style={{ height, overflow: "auto" }}>
-      {/* Editor is natural height; no height style here */}
+    <div
+      className="code-editor-viewport"
+      style={{
+        height,
+        overflow: "auto",
+        resize: "vertical",
+        minHeight: "120px",
+        maxHeight: "80vh",
+      }}
+      onClick={handleContainerClick}
+    >
       <Editor
+        ref={editorRef}
         value={value}
         onValueChange={onChange}
         highlight={(code) => highlightLuauCode(code)}


### PR DESCRIPTION
## Problem

There were some styling inconsistencies btwn the new code editor and the last (updated in 0.1.6)

## Solution

Align those inconsistencies:
- border radius + border
- make code editor vertically resizable
- clicking anywhere in the editor should focus input
