### PR TITLE
#chore update readme indicated lute version to latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ Use these formats for automatic changelog creation:
 ## 📋 Requirements
 
 - **VSCode** 1.74.0 or higher
-- **Lute** ([0.1.0-nightly.20251015](https://github.com/luau-lang/lute/releases/tag/0.1.0-nightly.20251015) or lower; migration to latest coming soon)
+- **Lute** (>= [0.1.0-nightly.20260130](https://github.com/luau-lang/lute/releases/tag/0.1.0-nightly.20260130))
 - **Foreman** or **Rokit** (See installation instructions linked above)
 - **Node.js** 16+ (for development)
 


### PR DESCRIPTION
## Problem

We mention an outdated lute version in the readme; as our latest release, we're compatible with Lute's 1/30 nightly and later.

## Solution

Indicate the updated version requirement
