### PR TITLE
#feat compatibility w/ lute to 0.1.0-nightly.20260312

### DIFF
--- a/.changes/68-feat.md
+++ b/.changes/68-feat.md
@@ -1,1 +1,1 @@
-compatibility w/ lute to 0.1.0-nightly.20260312
+Make compatible w/ lute to 0.1.0-nightly.20260312

--- a/.changes/68-feat.md
+++ b/.changes/68-feat.md
@@ -1,0 +1,1 @@
+compatibility w/ lute to 0.1.0-nightly.20260312

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ Use these formats for automatic changelog creation:
 ## 📋 Requirements
 
 - **VSCode** 1.74.0 or higher
-- **Lute** (>= [0.1.0-nightly.20260130](https://github.com/luau-lang/lute/releases/tag/0.1.0-nightly.20260130))
+- **Lute** (>= [0.1.0-nightly.20260312](https://github.com/luau-lang/lute/releases/tag/0.1.0-nightly.20260312))
 - **Foreman** or **Rokit** (See installation instructions linked above)
 - **Node.js** 16+ (for development)
 

--- a/foreman.toml
+++ b/foreman.toml
@@ -1,3 +1,3 @@
 [tools]
-lute = { source = "luau-lang/lute", version = "=0.1.0-nightly.20260130" }
+lute = { source = "luau-lang/lute", version = "=0.1.0-nightly.20260312" }
 stylua = { source = "JohnnyMorganz/StyLua", version = "2.0.2" }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,6 +23,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
+    "compile": "npm run build",
     "test": "react-scripts test --watchAll=false",
     "test:watch": "react-scripts test",
     "eject": "react-scripts eject"

--- a/frontend/src/tests/TreeNode.test.tsx
+++ b/frontend/src/tests/TreeNode.test.tsx
@@ -259,9 +259,9 @@ describe("TreeNode", () => {
     test("fallback chain: _astType -> parentInferred -> array inference", () => {
       // Test actual fallback: parent type defines array property, mixed content with/without _astType
       const tableWithEntries = {
-        _astType: "AstExprTable", // Parent type that has `entries: { AstExprTableItem }` property
+        _astType: "AstExprTable", // Parent type that has `entries: { AstTableExprItem }` property
         entries: [
-          { text: "filler" }, // No _astType - should infer AstExprTableItem from parent definition
+          { text: "filler" }, // No _astType - should infer AstTableExprItem from parent definition
           { _astType: "MySpecialType" }, // Has _astType - should use that directly
         ],
       };
@@ -275,14 +275,12 @@ describe("TreeNode", () => {
       // The entries array should get inferred type from AstExprTable definition
       const entriesQuery = getQueryableNode("root.entries", "nodeHeader");
       expect(
-        entriesQuery.getByText(/type: { AstExprTableItem }/)
+        entriesQuery.getByText(/type: { AstTableExprItem }/)
       ).toBeInTheDocument();
 
       // First item should infer type from parent array definition
       const item0Query = getQueryableNode("root.entries.0", "nodeHeader");
-      expect(
-        item0Query.getByText(/type: AstExprTableItem/)
-      ).toBeInTheDocument();
+      expect(item0Query.getByText(/type: AstTableExprItem/)).toBeInTheDocument();
 
       // Second item should use its explicit _astType
       const item1Query = getQueryableNode("root.entries.1", "nodeHeader");

--- a/frontend/src/tests/astTypeHelpers.test.ts
+++ b/frontend/src/tests/astTypeHelpers.test.ts
@@ -24,12 +24,12 @@ describe("astTypeHelpers", () => {
     expect(getArrayType("statements")).toEqual(["{ AstStat }", ""]);
 
     expect(getArrayType("entries", [{ colon: ":", kind: "record" }])).toEqual([
-      "{ AstTypeTableItem }",
+      "{ AstTableTypeItem }",
       "record",
     ]);
 
     expect(getArrayType("entries", [{ kind: "general" }])).toEqual([
-      "{ AstExprTableItem }",
+      "{ AstTableExprItem }",
       "general",
     ]);
 
@@ -105,14 +105,14 @@ describe("astTypeHelpers", () => {
 
     // leverages getArrayType
     expect(getTypeString([{}], "entries")).toEqual([
-      "{ AstExprTableItem }",
+      "{ AstTableExprItem }",
       "",
     ]);
 
     // falls back on parentInferredType
     expect(
-      getTypeString({ kind: "record" }, "[0]", "AstExprTableItem")
-    ).toEqual(["AstExprTableItem", "record"]);
+      getTypeString({ kind: "record" }, "[0]", "AstTableExprItem")
+    ).toEqual(["AstTableExprItem", "record"]);
   });
 
   test("getType", () => {

--- a/frontend/src/utils/astTypeDefinitions.ts
+++ b/frontend/src/utils/astTypeDefinitions.ts
@@ -216,6 +216,24 @@ export const astTypeDefinitions: Record<string, ASTTypeDefinition> = {
     ],
   },
 
+  AstExprInstantiate: {
+    properties: [
+      { name: "location", type: "span" },
+      { name: "kind", type: '"expr"' },
+      { name: "tag", type: '"instantiate"' },
+      { name: "expr", type: "AstExpr" },
+      { name: "leftarrow1", type: "Token", generic: 'Token<"<">' },
+      { name: "leftarrow2", type: "Token", generic: 'Token<"<">' },
+      {
+        name: "typearguments",
+        type: "Punctuated",
+        generic: "Punctuated<AstType | AstTypePack>",
+      },
+      { name: "rightarrow1", type: "Token", generic: 'Token<">">' },
+      { name: "rightarrow2", type: "Token", generic: 'Token<">">' },
+    ],
+  },
+
   AstExprIndexName: {
     properties: [
       { name: "location", type: "span" },
@@ -304,7 +322,7 @@ export const astTypeDefinitions: Record<string, ASTTypeDefinition> = {
     ],
   },
 
-  AstExprTableItemList: {
+  AstTableExprListItem: {
     properties: [
       { name: "location", type: "span" },
       { name: "kind", type: '"list"' },
@@ -319,7 +337,7 @@ export const astTypeDefinitions: Record<string, ASTTypeDefinition> = {
     ],
   },
 
-  AstExprTableItemRecord: {
+  AstTableExprRecordItem: {
     properties: [
       { name: "location", type: "span" },
       { name: "kind", type: '"record"' },
@@ -336,7 +354,7 @@ export const astTypeDefinitions: Record<string, ASTTypeDefinition> = {
     ],
   },
 
-  AstExprTableItemGeneral: {
+  AstTableExprGeneralItem: {
     properties: [
       { name: "location", type: "span" },
       { name: "kind", type: '"general"' },
@@ -355,11 +373,11 @@ export const astTypeDefinitions: Record<string, ASTTypeDefinition> = {
     ],
   },
 
-  AstExprTableItem: {
+  AstTableExprItem: {
     unionMembers: [
-      "AstExprTableItemList",
-      "AstExprTableItemRecord",
-      "AstExprTableItemGeneral",
+      "AstTableExprListItem",
+      "AstTableExprRecordItem",
+      "AstTableExprGeneralItem",
     ],
   },
 
@@ -369,7 +387,7 @@ export const astTypeDefinitions: Record<string, ASTTypeDefinition> = {
       { name: "kind", type: '"expr"' },
       { name: "tag", type: '"table"' },
       { name: "openbrace", type: "Token", generic: 'Token<"{">' },
-      { name: "entries", type: "{ AstExprTableItem }" },
+      { name: "entries", type: "{ AstTableExprItem }" },
       { name: "closebrace", type: "Token", generic: 'Token<"}">' },
     ],
   },
@@ -451,6 +469,7 @@ export const astTypeDefinitions: Record<string, ASTTypeDefinition> = {
       "AstExprGlobal",
       "AstExprVarargs",
       "AstExprCall",
+      "AstExprInstantiate",
       "AstExprIndexName",
       "AstExprIndexExpr",
       "AstExprFunction",
@@ -935,7 +954,7 @@ export const astTypeDefinitions: Record<string, ASTTypeDefinition> = {
     ],
   },
 
-  AstTypeTableItemIndexer: {
+  AstTableTypeItemIndexer: {
     properties: [
       { name: "kind", type: '"indexer"' },
       {
@@ -958,7 +977,7 @@ export const astTypeDefinitions: Record<string, ASTTypeDefinition> = {
     ],
   },
 
-  AstTypeTableItemStringProperty: {
+  AstTableTypeItemStringProperty: {
     properties: [
       { name: "kind", type: '"stringproperty"' },
       {
@@ -981,7 +1000,7 @@ export const astTypeDefinitions: Record<string, ASTTypeDefinition> = {
     ],
   },
 
-  AstTypeTableItemProperty: {
+  AstTableTypeItemProperty: {
     properties: [
       { name: "kind", type: '"property"' },
       {
@@ -1002,11 +1021,11 @@ export const astTypeDefinitions: Record<string, ASTTypeDefinition> = {
     ],
   },
 
-  AstTypeTableItem: {
+  AstTableTypeItem: {
     unionMembers: [
-      "AstTypeTableItemIndexer",
-      "AstTypeTableItemStringProperty",
-      "AstTypeTableItemProperty",
+      "AstTableTypeItemIndexer",
+      "AstTableTypeItemStringProperty",
+      "AstTableTypeItemProperty",
     ],
   },
 
@@ -1016,12 +1035,12 @@ export const astTypeDefinitions: Record<string, ASTTypeDefinition> = {
       { name: "kind", type: '"type"' },
       { name: "tag", type: '"table"' },
       { name: "openbrace", type: "Token", generic: 'Token<"{">' },
-      { name: "entries", type: "{ AstTypeTableItem }" },
+      { name: "entries", type: "{ AstTableTypeItem }" },
       { name: "closebrace", type: "Token", generic: 'Token<"}">' },
     ],
   },
 
-  AstTypeFunctionParameter: {
+  AstFunctionTypeParameter: {
     properties: [
       { name: "location", type: "span" },
       { name: "name", type: "Token", optional: true },
@@ -1063,7 +1082,7 @@ export const astTypeDefinitions: Record<string, ASTTypeDefinition> = {
       {
         name: "parameters",
         type: "Punctuated",
-        generic: "Punctuated<AstTypeFunctionParameter>",
+        generic: "Punctuated<AstFunctionTypeParameter>",
       },
       { name: "vararg", type: "AstTypePack", optional: true },
       { name: "closeparens", type: "Token", generic: 'Token<")">' },

--- a/frontend/src/utils/astTypeHelpers.ts
+++ b/frontend/src/utils/astTypeHelpers.ts
@@ -79,10 +79,10 @@ export function getAllNodeKeys(): string[] {
 
 const resolveEntriesType = (value: any[]): string => {
   if (value[0] && value[0].colon) {
-    return "{ AstTypeTableItem }";
+    return "{ AstTableTypeItem }";
   }
 
-  return "{ AstExprTableItem }";
+  return "{ AstTableExprItem }";
 };
 
 const resolveEntriesKind = (value: any[]): string => {

--- a/lua_helpers/typeAnnotations.lua
+++ b/lua_helpers/typeAnnotations.lua
@@ -280,7 +280,7 @@ local function resolveAmbiguousTags(node): string?
 	return typeDefinitions.tags[tag]
 end
 
-local function resolveAmbiguousKeys(nodeKey, node, parentNode): string?
+local function resolveAmbiguousKeys(nodeKey, node, parentNode: any?): string?
 	-- Handle 'kind' field specially - it's a discriminator, not a type
 	if nodeKey == "kind" then
 		return nil -- Don't annotate the kind field itself
@@ -380,7 +380,7 @@ local function resolveAmbiguousKeys(nodeKey, node, parentNode): string?
 	return typeDefinitions.keys[nodeKey]
 end
 
-local function annotateWithType(node, nodeKey, parent, parentKey)
+local function annotateWithType(node, nodeKey: (string | number)?, parent: any?, parentKey: (string | number)?)
 	if type(node) ~= "table" then
 		return node
 	end
@@ -414,7 +414,7 @@ local function annotateWithType(node, nodeKey, parent, parentKey)
 
 		-- Priority 5: Key-based type resolution (fallback)
 	elseif nodeKey then
-		astType = resolveAmbiguousKeys(nodeKey, annotatedNode, parent, parentKey)
+		astType = resolveAmbiguousKeys(nodeKey, annotatedNode, parent)
 
 		-- Priority 6: Generic token detection
 	elseif nodeKey and nodeKey:match("keyword$") then

--- a/lua_helpers/typeAnnotations.lua
+++ b/lua_helpers/typeAnnotations.lua
@@ -190,7 +190,7 @@ local typeDefinitions = {
 }
 
 -- Context-aware type resolution for ambiguous tags
-local function resolveAmbiguousTags(node)
+local function resolveAmbiguousTags(node): string?
 	local tag = node.tag
 	if not tag then
 		return nil
@@ -280,7 +280,7 @@ local function resolveAmbiguousTags(node)
 	return typeDefinitions.tags[tag]
 end
 
-local function resolveAmbiguousKeys(nodeKey, node, parentNode, parentKey)
+local function resolveAmbiguousKeys(nodeKey, node, parentNode): string?
 	-- Handle 'kind' field specially - it's a discriminator, not a type
 	if nodeKey == "kind" then
 		return nil -- Don't annotate the kind field itself
@@ -387,37 +387,34 @@ end
 
 		-- Lute AST nodes can be readonly in newer versions; avoid in-place mutation by
 		-- copying before annotating.
-		local out = {}
-		for key, value in pairs(node) do
-			out[key] = value
-		end
+		local annotatedNode = table.clone(node)
 
-		local astType = nil
+		local astType: string?
 
 		-- Priority 1: Check for 'kind' field for direct type mapping (local, attribute)
-		if out.kind == "local" and not out.tag then
+		if annotatedNode.kind == "local" and not annotatedNode.tag then
 			astType = "AstLocal"
-		elseif out.kind == "attribute" then
+		elseif annotatedNode.kind == "attribute" then
 			astType = "AstAttribute"
 
 		-- Priority 2: Context-aware tag-based type resolution
-		elseif out.tag then
-			astType = resolveAmbiguousTags(out)
+		elseif annotatedNode.tag then
+			astType = resolveAmbiguousTags(annotatedNode)
 
 		-- Priority 3: Check for 'kind' field for table items
-		elseif out.kind and out.istableitem then
-			astType = typeDefinitions.kinds[out.kind]
-		elseif out.kind and (out.key or out.indexeropen) then
+		elseif annotatedNode.kind and annotatedNode.istableitem then
+			astType = typeDefinitions.kinds[annotatedNode.kind]
+		elseif annotatedNode.kind and (annotatedNode.key or annotatedNode.indexeropen) then
 			-- Type table items
-			astType = typeDefinitions.kinds[out.kind]
+			astType = typeDefinitions.kinds[annotatedNode.kind]
 
 		-- Priority 4: Check for istoken marker
-		elseif out.istoken then
+		elseif annotatedNode.istoken then
 			astType = "Token"
 
 		-- Priority 5: Key-based type resolution (fallback)
 		elseif nodeKey then
-			astType = resolveAmbiguousKeys(nodeKey, out, parent, parentKey)
+			astType = resolveAmbiguousKeys(nodeKey, annotatedNode, parent, parentKey)
 
 		-- Priority 6: Generic token detection
 		elseif nodeKey and nodeKey:match("keyword$") then
@@ -429,17 +426,17 @@ end
 		end
 
 		-- Add type annotation (skip arrays to avoid JSON encoding issues)
-		if astType and not (#out > 0) then
-			out._astType = astType
+		if astType and not (#annotatedNode > 0) then
+			annotatedNode._astType = astType
 		end
 
 		-- Recursively annotate children, passing key context
-		for key, value in pairs(out) do
+		for key, value in annotatedNode do
 			if key ~= "_astType" then
-				out[key] = annotateWithType(value, if typeof(key) == "string" then key else tostring(key), out, nodeKey)
+				annotatedNode[key] = annotateWithType(value, if typeof(key) == "string" then key else tostring(key), annotatedNode, nodeKey)
 			end
 		end
-		return out
+		return annotatedNode
 	end
 
 return {

--- a/lua_helpers/typeAnnotations.lua
+++ b/lua_helpers/typeAnnotations.lua
@@ -380,64 +380,65 @@ local function resolveAmbiguousKeys(nodeKey, node, parentNode): string?
 	return typeDefinitions.keys[nodeKey]
 end
 
-	local function annotateWithType(node, nodeKey, parent, parentKey)
-		if type(node) ~= "table" then
-			return node
-		end
+local function annotateWithType(node, nodeKey, parent, parentKey)
+	if type(node) ~= "table" then
+		return node
+	end
 
-		-- Lute AST nodes can be readonly in newer versions; avoid in-place mutation by
-		-- copying before annotating.
-		local annotatedNode = table.clone(node)
+	-- Lute AST nodes can be readonly in newer versions; avoid in-place mutation by
+	-- copying before annotating.
+	local annotatedNode = table.clone(node)
 
-		local astType: string?
+	local astType: string?
 
-		-- Priority 1: Check for 'kind' field for direct type mapping (local, attribute)
-		if annotatedNode.kind == "local" and not annotatedNode.tag then
-			astType = "AstLocal"
-		elseif annotatedNode.kind == "attribute" then
-			astType = "AstAttribute"
+	-- Priority 1: Check for 'kind' field for direct type mapping (local, attribute)
+	if annotatedNode.kind == "local" and not annotatedNode.tag then
+		astType = "AstLocal"
+	elseif annotatedNode.kind == "attribute" then
+		astType = "AstAttribute"
 
 		-- Priority 2: Context-aware tag-based type resolution
-		elseif annotatedNode.tag then
-			astType = resolveAmbiguousTags(annotatedNode)
+	elseif annotatedNode.tag then
+		astType = resolveAmbiguousTags(annotatedNode)
 
 		-- Priority 3: Check for 'kind' field for table items
-		elseif annotatedNode.kind and annotatedNode.istableitem then
-			astType = typeDefinitions.kinds[annotatedNode.kind]
-		elseif annotatedNode.kind and (annotatedNode.key or annotatedNode.indexeropen) then
-			-- Type table items
-			astType = typeDefinitions.kinds[annotatedNode.kind]
+	elseif annotatedNode.kind and annotatedNode.istableitem then
+		astType = typeDefinitions.kinds[annotatedNode.kind]
+	elseif annotatedNode.kind and (annotatedNode.key or annotatedNode.indexeropen) then
+		-- Type table items
+		astType = typeDefinitions.kinds[annotatedNode.kind]
 
 		-- Priority 4: Check for istoken marker
-		elseif annotatedNode.istoken then
-			astType = "Token"
+	elseif annotatedNode.istoken then
+		astType = "Token"
 
 		-- Priority 5: Key-based type resolution (fallback)
-		elseif nodeKey then
-			astType = resolveAmbiguousKeys(nodeKey, annotatedNode, parent, parentKey)
+	elseif nodeKey then
+		astType = resolveAmbiguousKeys(nodeKey, annotatedNode, parent, parentKey)
 
 		-- Priority 6: Generic token detection
-		elseif nodeKey and nodeKey:match("keyword$") then
-			-- Any property ending in "keyword" is probably a token
-			astType = "Token"
-		elseif nodeKey and (nodeKey:match("^open") or nodeKey:match("^close")) then
-			-- Properties like openparens, closebrace, etc.
-			astType = "Token"
-		end
-
-		-- Add type annotation (skip arrays to avoid JSON encoding issues)
-		if astType and not (#annotatedNode > 0) then
-			annotatedNode._astType = astType
-		end
-
-		-- Recursively annotate children, passing key context
-		for key, value in annotatedNode do
-			if key ~= "_astType" then
-				annotatedNode[key] = annotateWithType(value, if typeof(key) == "string" then key else tostring(key), annotatedNode, nodeKey)
-			end
-		end
-		return annotatedNode
+	elseif nodeKey and nodeKey:match("keyword$") then
+		-- Any property ending in "keyword" is probably a token
+		astType = "Token"
+	elseif nodeKey and (nodeKey:match("^open") or nodeKey:match("^close")) then
+		-- Properties like openparens, closebrace, etc.
+		astType = "Token"
 	end
+
+	-- Add type annotation (skip arrays to avoid JSON encoding issues)
+	if astType and not (#annotatedNode > 0) then
+		annotatedNode._astType = astType
+	end
+
+	-- Recursively annotate children, passing key context
+	for key, value in annotatedNode do
+		if key ~= "_astType" then
+			annotatedNode[key] =
+				annotateWithType(value, if typeof(key) == "string" then key else tostring(key), annotatedNode, nodeKey)
+		end
+	end
+	return annotatedNode
+end
 
 return {
 	annotateWithType = annotateWithType,

--- a/lua_helpers/typeAnnotations.lua
+++ b/lua_helpers/typeAnnotations.lua
@@ -21,6 +21,7 @@ local typeDefinitions = {
 		["global"] = "AstExprGlobal",
 		["vararg"] = "AstExprVarargs",
 		["call"] = "AstExprCall",
+		["instantiate"] = "AstExprInstantiate",
 		["indexname"] = "AstExprIndexName",
 		["index"] = "AstExprIndexExpr",
 		["unary"] = "AstExprUnary",
@@ -171,14 +172,14 @@ local typeDefinitions = {
 	-- Kind-based mappings for table items and other kinded structures
 	kinds = {
 		-- Expression table items (istableitem: true)
-		["record"] = "AstExprTableItemRecord",
-		["general"] = "AstExprTableItemGeneral",
-		["list"] = "AstExprTableItemList",
+		["record"] = "AstTableExprRecordItem",
+		["general"] = "AstTableExprGeneralItem",
+		["list"] = "AstTableExprListItem",
 
 		-- Type table items
-		["property"] = "AstTypeTableItemProperty",
-		["indexer"] = "AstTypeTableItemIndexer",
-		["stringproperty"] = "AstTypeTableItemStringProperty",
+		["property"] = "AstTableTypeItemProperty",
+		["indexer"] = "AstTableTypeItemIndexer",
+		["stringproperty"] = "AstTableTypeItemStringProperty",
 
 		-- AstLocal
 		["local"] = "AstLocal",

--- a/lua_helpers/typeAnnotations.lua
+++ b/lua_helpers/typeAnnotations.lua
@@ -379,60 +379,67 @@ local function resolveAmbiguousKeys(nodeKey, node, parentNode, parentKey)
 	return typeDefinitions.keys[nodeKey]
 end
 
-local function annotateWithType(node, nodeKey, parent, parentKey)
-	if type(node) ~= "table" then
-		return node
-	end
-
-	local astType = nil
-
-	-- Priority 1: Check for 'kind' field for direct type mapping (local, attribute)
-	if node.kind == "local" and not node.tag then
-		astType = "AstLocal"
-	elseif node.kind == "attribute" then
-		astType = "AstAttribute"
-
-	-- Priority 2: Context-aware tag-based type resolution
-	elseif node.tag then
-		astType = resolveAmbiguousTags(node)
-
-	-- Priority 3: Check for 'kind' field for table items
-	elseif node.kind and node.istableitem then
-		astType = typeDefinitions.kinds[node.kind]
-	elseif node.kind and (node.key or node.indexeropen) then
-		-- Type table items
-		astType = typeDefinitions.kinds[node.kind]
-
-	-- Priority 4: Check for istoken marker
-	elseif node.istoken then
-		astType = "Token"
-
-	-- Priority 5: Key-based type resolution (fallback)
-	elseif nodeKey then
-		astType = resolveAmbiguousKeys(nodeKey, node, parent, parentKey)
-
-	-- Priority 6: Generic token detection
-	elseif nodeKey and nodeKey:match("keyword$") then
-		-- Any property ending in "keyword" is probably a token
-		astType = "Token"
-	elseif nodeKey and (nodeKey:match("^open") or nodeKey:match("^close")) then
-		-- Properties like openparens, closebrace, etc.
-		astType = "Token"
-	end
-
-	-- Add type annotation (skip arrays to avoid JSON encoding issues)
-	if astType and not (#node > 0) then
-		node._astType = astType
-	end
-
-	-- Recursively annotate children, passing key context
-	for key, value in pairs(node) do
-		if key ~= "_astType" then
-			node[key] = annotateWithType(value, if typeof(key) == "string" then key else tostring(key), node, nodeKey)
+	local function annotateWithType(node, nodeKey, parent, parentKey)
+		if type(node) ~= "table" then
+			return node
 		end
+
+		-- Lute AST nodes can be readonly in newer versions; avoid in-place mutation by
+		-- copying before annotating.
+		local out = {}
+		for key, value in pairs(node) do
+			out[key] = value
+		end
+
+		local astType = nil
+
+		-- Priority 1: Check for 'kind' field for direct type mapping (local, attribute)
+		if out.kind == "local" and not out.tag then
+			astType = "AstLocal"
+		elseif out.kind == "attribute" then
+			astType = "AstAttribute"
+
+		-- Priority 2: Context-aware tag-based type resolution
+		elseif out.tag then
+			astType = resolveAmbiguousTags(out)
+
+		-- Priority 3: Check for 'kind' field for table items
+		elseif out.kind and out.istableitem then
+			astType = typeDefinitions.kinds[out.kind]
+		elseif out.kind and (out.key or out.indexeropen) then
+			-- Type table items
+			astType = typeDefinitions.kinds[out.kind]
+
+		-- Priority 4: Check for istoken marker
+		elseif out.istoken then
+			astType = "Token"
+
+		-- Priority 5: Key-based type resolution (fallback)
+		elseif nodeKey then
+			astType = resolveAmbiguousKeys(nodeKey, out, parent, parentKey)
+
+		-- Priority 6: Generic token detection
+		elseif nodeKey and nodeKey:match("keyword$") then
+			-- Any property ending in "keyword" is probably a token
+			astType = "Token"
+		elseif nodeKey and (nodeKey:match("^open") or nodeKey:match("^close")) then
+			-- Properties like openparens, closebrace, etc.
+			astType = "Token"
+		end
+
+		-- Add type annotation (skip arrays to avoid JSON encoding issues)
+		if astType and not (#out > 0) then
+			out._astType = astType
+		end
+
+		-- Recursively annotate children, passing key context
+		for key, value in pairs(out) do
+			if key ~= "_astType" then
+				out[key] = annotateWithType(value, if typeof(key) == "string" then key else tostring(key), out, nodeKey)
+			end
+		end
+		return out
 	end
-	return node
-end
 
 return {
 	annotateWithType = annotateWithType,

--- a/lua_tests/helpers/astJsonToCodeHelpers.lua
+++ b/lua_tests/helpers/astJsonToCodeHelpers.lua
@@ -99,6 +99,7 @@ local cases = {
 		"type Generic<T> = { data: T }",
 		"type Props = { titleText: string, avatarThumbnail: string, avatarThumbnailDisplayHeight: number, bodyText: string?, primaryButtonText: string, onPrimaryButtonActivated: () -> ()?, secondaryButtonText: string?, onSecondaryButtonActivated: () -> ()?, closeCentralOverlayThunk: () -> any? }",
 		"local nil_val = nil",
+		"a<<string>>",
 		-- Edge cases that test printASTNode fallback behavior
 		"local x",
 		"local y: number",

--- a/lua_tests/helpers/astJsonToCodeHelpers.lua
+++ b/lua_tests/helpers/astJsonToCodeHelpers.lua
@@ -99,7 +99,7 @@ local cases = {
 		"type Generic<T> = { data: T }",
 		"type Props = { titleText: string, avatarThumbnail: string, avatarThumbnailDisplayHeight: number, bodyText: string?, primaryButtonText: string, onPrimaryButtonActivated: () -> ()?, secondaryButtonText: string?, onSecondaryButtonActivated: () -> ()?, closeCentralOverlayThunk: () -> any? }",
 		"local nil_val = nil",
-		"a<<string>>",
+		"local b = a<<string>>",
 		-- Edge cases that test printASTNode fallback behavior
 		"local x",
 		"local y: number",

--- a/lua_tests/helpers/typeAnnotationTestHelpers.lua
+++ b/lua_tests/helpers/typeAnnotationTestHelpers.lua
@@ -212,6 +212,11 @@ typeAnnotationVisitor.visitExprTable = function(node: luau.AstExprTable)
 	return true
 end
 
+typeAnnotationVisitor.visitExprInstantiate = function(node: luau.AstExprInstantiate)
+	verifyOutput(node, "visitTable", node._astType == "AstExprInstantiate")
+	return true
+end
+
 -- Type visitors
 typeAnnotationVisitor.visitTypeReference = function(node: luau.AstTypeReference)
 	verifyOutput(node, "visitTypeReference", node._astType == "AstTypeReference")

--- a/lua_tests/helpers/typeAnnotationTestHelpers.lua
+++ b/lua_tests/helpers/typeAnnotationTestHelpers.lua
@@ -213,7 +213,7 @@ typeAnnotationVisitor.visitExprTable = function(node: luau.AstExprTable)
 end
 
 typeAnnotationVisitor.visitExprInstantiate = function(node: luau.AstExprInstantiate)
-	verifyOutput(node, "visitTable", node._astType == "AstExprInstantiate")
+	verifyOutput(node, "visitExprInstantiate", node._astType == "AstExprInstantiate")
 	return true
 end
 

--- a/lua_tests/typeAnnotations.spec.lua
+++ b/lua_tests/typeAnnotations.spec.lua
@@ -8,7 +8,7 @@ local typeAnnotationHelpers = require("./helpers/typeAnnotationTestHelpers")
 
 local function annotateWithType_test()
 	-- parse and annotate src code snippet (with large coverage of syntax constructs)
-	local testAST = annotateWithType(parser.parseblock(typeAnnotationHelpers.testSrc))
+	local testAST = annotateWithType(parser.parseblock(typeAnnotationHelpers.testSrc) :: any)
 	-- visit annotated tree to check for correct type assignment (using typeAnnotationVisitor)
 	local typeAnnotationChecker = typeAnnotationHelpers.typeAnnotationVisitor
 	visitor.visit(testAST, typeAnnotationChecker)

--- a/rokit.toml
+++ b/rokit.toml
@@ -1,3 +1,3 @@
 [tools]
-lute = "luau-lang/lute@0.1.0-nightly.20260130"
+lute = "luau-lang/lute@0.1.0-nightly.20260312"
 stylua = "JohnnyMorganz/StyLua@2.0.2"


### PR DESCRIPTION
## Summary
- Bump Lute: `0.1.0-nightly.20260130` -> `0.1.0-nightly.20260312`.

## Type-def observations
- The Luau type definitions fetched from Lute changed noticeably between these releases (defs diff approx `+527/-428` lines).
- With `0.1.0-nightly.20260312`, AST tables appear to be readonly; `lua_helpers/typeAnnotations.lua` now copies nodes before adding `_astType` and recursing.

## Tests
- `npm run test:compile`: pass
- `lute run lua_tests/runner.luau`: pass

## Notes / Next steps
- If we hit other readonly-table errors, audit other Lua helpers for in-place AST mutation.
