### PR TITLE
chore: bump lute to 0.1.0-nightly.20260320

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ Use these formats for automatic changelog creation:
 ## 📋 Requirements
 
 - **VSCode** 1.74.0 or higher
-- **Lute** (>= [0.1.0-nightly.20260312](https://github.com/luau-lang/lute/releases/tag/0.1.0-nightly.20260312))
+- **Lute** (>= [0.1.0-nightly.20260320](https://github.com/luau-lang/lute/releases/tag/0.1.0-nightly.20260320))
 - **Foreman** or **Rokit** (See installation instructions linked above)
 - **Node.js** 16+ (for development)
 

--- a/foreman.toml
+++ b/foreman.toml
@@ -1,3 +1,3 @@
 [tools]
-lute = { source = "luau-lang/lute", version = "=0.1.0-nightly.20260312" }
+lute = { source = "luau-lang/lute", version = "=0.1.0-nightly.20260320" }
 stylua = { source = "JohnnyMorganz/StyLua", version = "2.0.2" }

--- a/lua_helpers/temp_vendor/lutePrinter.luau
+++ b/lua_helpers/temp_vendor/lutePrinter.luau
@@ -1,6 +1,35 @@
 local lp = require("@std/syntax/printer")
 local getSortedChildren = require("../sortByPositionTable")
 
+local function isTokenLike(node: any): boolean
+	return typeof(node) == "table" and (node.kind == "token" or node.istoken == true) and type(node.text) == "string"
+end
+
+local function printTokenLike(node: any): string
+	local src = ""
+	local leading = node.leadingtrivia
+	if typeof(leading) == "table" then
+		for _, triv in leading do
+			if typeof(triv) == "table" and type(triv.text) == "string" then
+				src ..= triv.text
+			end
+		end
+	end
+
+	src ..= node.text
+
+	local trailing = node.trailingtrivia
+	if typeof(trailing) == "table" then
+		for _, triv in trailing do
+			if typeof(triv) == "table" and type(triv.text) == "string" then
+				src ..= triv.text
+			end
+		end
+	end
+
+	return src
+end
+
 local function printFallback(node: any): string
 	--[[
 		Function to serve as fallback when nodes are not printable with printstatement, printexpr, printtype, printlocal, printtoken
@@ -9,6 +38,10 @@ local function printFallback(node: any): string
 		if non-array node: sort children by position, iteratively try to print children (same way as above)
 	]]
 	local nodeSrcStr = ""
+	if typeof(node) == "table" and node.token ~= nil then
+		-- Newer Lute defs wrap some constants / varargs in a `{ token = Token }` shape.
+		return printASTNode(node.token) or ""
+	end
 	if node[1] then -- handle arrays
 		for i = 1, #node do
 			nodeSrcStr ..= printASTNode(node[i]) or ""
@@ -49,6 +82,10 @@ end
 function printASTNode(astNode: any): string | nil
 	-- filter nodes lefover from diff annotations that we DONT want to print
 	astNode = filterNodeForPrinting(astNode)
+
+	if isTokenLike(astNode) then
+		return printTokenLike(astNode)
+	end
 
 	local success, defaultPrint = pcall(lp.printnode, astNode)
 	if success then

--- a/rokit.toml
+++ b/rokit.toml
@@ -1,3 +1,3 @@
 [tools]
-lute = "luau-lang/lute@0.1.0-nightly.20260312"
+lute = "luau-lang/lute@0.1.0-nightly.20260320"
 stylua = "JohnnyMorganz/StyLua@2.0.2"


### PR DESCRIPTION
Old Lute tag: 0.1.0-nightly.20260312
New Lute tag: 0.1.0-nightly.20260320

What changed
- Bumped Lute pins in rokit/foreman and updated README minimum version.

Type-def observations (high level)
- Tokens use `kind = "token"` (vs older `istoken = true` shape used by some fixtures).
- Some constants / varargs wrap the underlying token via a `{ token = Token }` field.

Test results
- `npm run test:compile`: PASS
- `lute run lua_tests/runner.luau`: PASS

Implementation notes
- Updated the Lua printer fallback to handle both token shapes and `{ token = Token }` wrappers.

Next steps
- If any downstream code assumes `istoken`, prefer checking `kind == "token"` or handling both.
